### PR TITLE
csmPPI-import-bug

### DIFF
--- a/wisdem/nrelcsm/csmPPI.py
+++ b/wisdem/nrelcsm/csmPPI.py
@@ -5,7 +5,7 @@ Created by George Scott on 2012-08-01.
 Modified by Katherine Dykes 2012.
 Copyright (c) NREL. All rights reserved.
 """
-import wisdem.nrelcsm
+import wisdem.nrelcsm as nrelcsm
 import os
 import sys
 import re


### PR DESCRIPTION
This fixes an import that causes some script using the nrelcsm module to
fail.