### PR TITLE
Precommit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E731,E402,F,W504,W503
+ignore = E731,E402,F,W504,W503,E501,C901
 exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
 max-complexity = 10
 max-line-length=120

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E731,E402,F,W504,W503
+exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
+max-complexity = 10
+max-line-length=120

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,9 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=120
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+known_first_party=wisdem
+length_sort=1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
-    -   id: check-executables-have-shebangs
+    # -   id: check-executables-have-shebangs
     -   id: check-json
     -   id: check-yaml
     -   id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+-   repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
+    hooks:
+        - id: isort
+          name: isort
+          stages: [commit]
+
+-   repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+        - id: black
+          name: black
+          stages: [commit]
+          language_version: python3.8
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-executables-have-shebangs
+    -   id: check-json
+    -   id: check-yaml
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: flake8
+        exclude: ^docs/
+    -   id: mixed-line-ending
+    -   id: pretty-format-json
+        args: [--autofix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.black]
+line-length = 120
+target-version = ['py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''

--- a/wisdem/glue_code/runWISDEM.py
+++ b/wisdem/glue_code/runWISDEM.py
@@ -1,13 +1,15 @@
-import numpy as np
 import os
 import sys
+
+import numpy as np
+
 import openmdao.api as om
+from wisdem.commonse import fileIO
+from wisdem.commonse.mpi_tools import MPI
+from wisdem.glue_code.glue_code import WindPark
 from wisdem.glue_code.gc_LoadInputs import WindTurbineOntologyPython
 from wisdem.glue_code.gc_WT_InitModel import yaml2openmdao
 from wisdem.glue_code.gc_PoseOptimization import PoseOptimization
-from wisdem.glue_code.glue_code import WindPark
-from wisdem.commonse.mpi_tools import MPI
-from wisdem.commonse import fileIO
 
 np.warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
 


### PR DESCRIPTION
Tried to follow tips from [here](https://medium.com/staqu-dev-logs/keeping-python-code-clean-with-pre-commit-hooks-black-flake8-and-isort-cac8b01e0ea1) and from the ORBIT repo, which has more hooks than this.  I think all you need to do, as a developer, is (from your local WISDEM clone):
`pip install pre-commit`
`pre-commit install`

This will likely need some tweaks as we start using it and get frustrated with various behaviors.