### PR TITLE
reset limits poisson ratios

### DIFF
--- a/wisdem/inputs/geometry_schema.yaml
+++ b/wisdem/inputs/geometry_schema.yaml
@@ -1926,7 +1926,7 @@ properties:
                             uniqueItems: false
                             minimum: 0
                 nu:
-                    description: Poisson ratio. For orthotropic materials, it consists of an array with nu12, nu13 and nu23. For isotropic materials, a minimum of -1 and a maximum of 0.5 are imposed. No limits are imposed to anistropic materials.
+                    description: Poisson ratio. For orthotropic materials, it consists of an array with nu12, nu13 and nu23. For isotropic materials, a minimum of -1 and a maximum of 0.5 are imposed. No limits are imposed to anisotropic materials.
                     oneOf:
                         - type: number
                           unit: none

--- a/wisdem/inputs/geometry_schema.yaml
+++ b/wisdem/inputs/geometry_schema.yaml
@@ -1926,11 +1926,12 @@ properties:
                             uniqueItems: false
                             minimum: 0
                 nu:
-                    description: Poisson ratio. For orthotropic materials, it consists of an array with nu12, nu13 and nu23
+                    description: Poisson ratio. For orthotropic materials, it consists of an array with nu12, nu13 and nu23. For isotropic materials, a minimum of -1 and a maximum of 0.5 are imposed. No limits are imposed to anistropic materials.
                     oneOf:
                         - type: number
                           unit: none
-                          minimum: 0
+                          minimum: -1.
+                          maximum: 0.5
                         - type: array
                           items:
                             type: number
@@ -1938,8 +1939,6 @@ properties:
                             minItems: 3
                             maxItems: 3
                             uniqueItems: false
-                            minimum: 0
-                            maximum: 0.6
                 alpha:
                     description: Thermal coefficient of expansion
                     oneOf:


### PR DESCRIPTION
Enforce limits of Poisson ratios in the schema only for isotropic materials. I will update the IEA repo windIO as well.

## Purpose
A wrong upper limit of 0.6 was imposed in the geometry schema yaml for the Poisson ratios of anisotropic materials. New materials for the BAR rotors have Poisson ratios above the older limit of 0.6.
Isotropic materials have Poisson ratios between -1 and 0.5, but anisotropic materials can indeed go outside these bounds

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Tests should not be affected

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation