### PR TITLE
moving all tower discretization content to TowerSE instead of ontology read

### DIFF
--- a/examples/05_tower_monopile/monopile_direct.py
+++ b/examples/05_tower_monopile/monopile_direct.py
@@ -19,14 +19,14 @@ hubH = 87.6
 htrans = 10.0
 h_paramT = np.diff(np.linspace(htrans, hubH, n_control_points))
 d_paramT = np.linspace(7.0, 3.87, n_control_points)
-t_paramT = 1.3 * np.linspace(0.025, 0.021, n_control_points - 1)
+t_paramT = 1.3 * np.linspace(0.025, 0.021, n_control_points)
 
 # Monopile initial condition
 pile_depth = 25.0
 water_depth = 30.0
 h_paramM = np.r_[pile_depth, water_depth, htrans]
 d_paramM = np.linspace(8.0, 7.0, n_control_points)
-t_paramM = 0.025 * np.ones(n_control_points - 1)
+t_paramM = 0.025 * np.ones(n_control_points)
 
 max_diam = 8.0
 # ---

--- a/examples/05_tower_monopile/tower_direct.py
+++ b/examples/05_tower_monopile/tower_direct.py
@@ -18,7 +18,7 @@ n_load_cases = 2
 
 h_param = np.diff(np.linspace(0.0, 87.6, n_control_points))
 d_param = np.linspace(6.0, 3.87, n_control_points)
-t_param = 1.3 * np.linspace(0.025, 0.021, n_control_points - 1)
+t_param = 1.3 * np.linspace(0.025, 0.021, n_control_points)
 max_diam = 8.0
 # ---
 

--- a/examples/09_floating/semi_example.py
+++ b/examples/09_floating/semi_example.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 import openmdao.api as om
-from wisdem.floatingse import FloatingSE
 from wisdem.commonse import fileIO
+from wisdem.floatingse import FloatingSE
 
 plot_flag = False  # True
 opt_flag = False
@@ -168,7 +168,7 @@ nTower = prob.model.options["modeling_options"]["TowerSE"]["n_height_tower"] - 1
 prob["tower_height"] = prob["hub_height"] = 77.6
 prob["tower_s"] = np.linspace(0.0, 1.0, nTower + 1)
 prob["tower_outer_diameter_in"] = np.linspace(8.0, 3.87, nTower + 1)
-prob["tower_layer_thickness"] = np.linspace(0.04, 0.02, nTower).reshape((1, nTower))
+prob["tower_layer_thickness"] = np.linspace(0.04, 0.02, nTower + 1).reshape((1, nTower + 1))
 prob["tower_outfitting_factor"] = 1.07
 
 # Materials

--- a/examples/09_floating/spar_example.py
+++ b/examples/09_floating/spar_example.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 import openmdao.api as om
-from wisdem.floatingse import FloatingSE
 from wisdem.commonse import fileIO
+from wisdem.floatingse import FloatingSE
 
 plot_flag = False  # True
 opt_flag = False
@@ -156,7 +156,7 @@ nTower = prob.model.options["modeling_options"]["TowerSE"]["n_height_tower"] - 1
 prob["tower_height"] = prob["hub_height"] = 77.6
 prob["tower_s"] = np.linspace(0.0, 1.0, nTower + 1)
 prob["tower_outer_diameter_in"] = np.linspace(8.0, 3.87, nTower + 1)
-prob["tower_layer_thickness"] = np.linspace(0.04, 0.02, nTower).reshape((1, nTower))
+prob["tower_layer_thickness"] = np.linspace(0.04, 0.02, nTower + 1).reshape((1, nTower + 1))
 prob["tower_outfitting_factor"] = 1.07
 
 # Materials

--- a/examples/09_floating/spar_opt.py
+++ b/examples/09_floating/spar_opt.py
@@ -3,8 +3,8 @@
 # Optimization of OC3 spar (by flag)
 import numpy as np
 import openmdao.api as om
-from wisdem.floatingse import FloatingSE
 from wisdem.commonse import fileIO
+from wisdem.floatingse import FloatingSE
 
 plot_flag = False
 opt_flag = False
@@ -187,7 +187,7 @@ nTower = prob.model.options["modeling_options"]["TowerSE"]["n_height_tower"] - 1
 prob["tower_height"] = prob["hub_height"] = 77.6
 prob["tower_s"] = np.linspace(0.0, 1.0, nTower + 1)
 prob["tower_outer_diameter_in"] = np.linspace(min_diam, 3.87, nTower + 1)
-prob["tower_layer_thickness"] = np.linspace(0.04, 0.02, nTower).reshape((1, nTower))
+prob["tower_layer_thickness"] = np.linspace(0.04, 0.02, nTower + 1).reshape((1, nTower + 1))
 prob["tower_outfitting_factor"] = 1.07
 
 # Materials

--- a/examples/09_floating/tlp_example.py
+++ b/examples/09_floating/tlp_example.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 import openmdao.api as om
-from wisdem.floatingse import FloatingSE
 from wisdem.commonse import fileIO
+from wisdem.floatingse import FloatingSE
 
 plot_flag = False  # True
 opt_flag = False
@@ -162,7 +162,7 @@ nTower = prob.model.options["modeling_options"]["TowerSE"]["n_height_tower"] - 1
 prob["tower_height"] = prob["hub_height"] = 77.6
 prob["tower_s"] = np.linspace(0.0, 1.0, nTower + 1)
 prob["tower_outer_diameter_in"] = np.linspace(8.0, 3.87, nTower + 1)
-prob["tower_layer_thickness"] = np.linspace(0.04, 0.02, nTower).reshape((1, nTower))
+prob["tower_layer_thickness"] = np.linspace(0.04, 0.02, nTower + 1).reshape((1, nTower + 1))
 prob["tower_outfitting_factor"] = 1.07
 
 # Materials

--- a/wisdem/glue_code/gc_LoadInputs.py
+++ b/wisdem/glue_code/gc_LoadInputs.py
@@ -898,7 +898,7 @@ class WindTurbineOntologyPython(object):
                 ] = wt_opt["tower_grid.s"].tolist()
                 self.wt_init["components"]["tower"]["internal_structure_2d_fem"]["layers"][i]["thickness"][
                     "values"
-                ] = np.hstack((wt_opt["tower.layer_thickness"][i, :], wt_opt["tower.layer_thickness"][i, -1])).tolist()
+                ] = wt_opt["tower.layer_thickness"][i, :].tolist()
 
         # Update monopile
         if self.modeling_options["flags"]["monopile"]:

--- a/wisdem/glue_code/gc_WT_DataStruc.py
+++ b/wisdem/glue_code/gc_WT_DataStruc.py
@@ -330,7 +330,7 @@ class WindTurbineOntologyOpenMDAO(om.Group):
             )
             ivc.add_output(
                 "layer_thickness",
-                val=np.zeros((n_layers_tower, n_height_tower - 1)),
+                val=np.zeros((n_layers_tower, n_height_tower)),
                 units="m",
                 desc="2D array of the thickness of the layers of the tower structure. The first dimension represents each layer, the second dimension represents each piecewise-constant entry of the tower sections.",
             )
@@ -1447,7 +1447,7 @@ class Compute_Blade_Internal_Structure_2D_FEM(om.ExplicitComponent):
                         'WARNING: Web "%s" may be too large to fit within chord. "offset_x_pa" changed from %f to %f at R=%f (i=%d)'
                         % (web_name[j], offset_old, offset, inputs["s"][i], i)
                     )
-                    #print(layer_resize_warning)
+                    # print(layer_resize_warning)
                 else:
                     outputs["web_offset_y_pa"][j, i] = copy.copy(offset)
 
@@ -1535,7 +1535,7 @@ class Compute_Blade_Internal_Structure_2D_FEM(om.ExplicitComponent):
                             'WARNING: Layer "%s" may be too large to fit within chord. "offset_y_pa" changed from %f to 0.0 and "width" changed from %f to %f at s=%f (i=%d)'
                             % (layer_name[j], offset, width_old, width, inputs["s"][i], i)
                         )
-                        #print(layer_resize_warning)
+                        # print(layer_resize_warning)
                     else:
                         outputs["layer_width"][j, i] = copy.copy(width)
                         outputs["layer_offset_y_pa"][j, i] = copy.copy(offset)
@@ -1554,12 +1554,12 @@ class Compute_Blade_Internal_Structure_2D_FEM(om.ExplicitComponent):
                     # # Geometry check to prevent overlap between SC and TE reinf
                     # for k in range(self.n_layers):
                     #     if discrete_inputs["definition_layer"][k] == 2 or discrete_inputs["definition_layer"][k] == 3:
-                            # if layer_end_nd[j, i] > layer_start_nd[k, i] or layer_start_nd[j, i] < layer_end_nd[k, i]:
-                            #     print(
-                            #         "WARNING: The trailing edge reinforcement extends above the spar caps at station "
-                            #         + str(i)
-                            #         + ". Please reduce its width."
-                            #     )
+                    # if layer_end_nd[j, i] > layer_start_nd[k, i] or layer_start_nd[j, i] < layer_end_nd[k, i]:
+                    #     print(
+                    #         "WARNING: The trailing edge reinforcement extends above the spar caps at station "
+                    #         + str(i)
+                    #         + ". Please reduce its width."
+                    #     )
 
                 elif discrete_inputs["definition_layer"][j] == 5:  # Midpoint and width
                     midpoint = LE_loc
@@ -1836,7 +1836,7 @@ class Monopile(om.Group):
         )
         ivc.add_output(
             "layer_thickness",
-            val=np.zeros((n_layers, n_height - 1)),
+            val=np.zeros((n_layers, n_height)),
             units="m",
             desc="2D array of the thickness of the layers of the tower structure. The first dimension represents each layer, the second dimension represents each piecewise-constant entry of the tower sections.",
         )

--- a/wisdem/glue_code/gc_WT_InitModel.py
+++ b/wisdem/glue_code/gc_WT_InitModel.py
@@ -803,7 +803,7 @@ def assign_tower_values(wt_opt, modeling_options, tower):
 
     wt_opt["tower.layer_name"] = layer_name
     wt_opt["tower.layer_mat"] = layer_mat
-    wt_opt["tower.layer_thickness"] = 0.5 * (thickness[:, :-1] + thickness[:, 1:])
+    wt_opt["tower.layer_thickness"] = thickness
 
     wt_opt["tower.outfitting_factor"] = tower["internal_structure_2d_fem"]["outfitting_factor"]
 
@@ -871,7 +871,7 @@ def assign_monopile_values(wt_opt, modeling_options, monopile):
 
     wt_opt["monopile.layer_name"] = layer_name
     wt_opt["monopile.layer_mat"] = layer_mat
-    wt_opt["monopile.layer_thickness"] = 0.5 * (thickness[:, :-1] + thickness[:, 1:])
+    wt_opt["monopile.layer_thickness"] = thickness
 
     wt_opt["monopile.outfitting_factor"] = monopile["internal_structure_2d_fem"]["outfitting_factor"]
     wt_opt["monopile.transition_piece_mass"] = monopile["transition_piece_mass"]

--- a/wisdem/test/test_floatingse/test_floating.py
+++ b/wisdem/test/test_floatingse/test_floating.py
@@ -176,7 +176,7 @@ class TestOC3Mass(unittest.TestCase):
         prob["tower_height"] = prob["hub_height"] = 77.6
         prob["tower_s"] = np.linspace(0.0, 1.0, nTower + 1)
         prob["tower_outer_diameter_in"] = np.linspace(6.5, 3.87, nTower + 1)
-        prob["tower_layer_thickness"] = np.linspace(0.027, 0.019, nTower).reshape((1, nTower))
+        prob["tower_layer_thickness"] = np.linspace(0.027, 0.019, nTower + 1).reshape((1, nTower + 1))
         prob["tower_outfitting_factor"] = 1.07
 
         # Materials

--- a/wisdem/test/test_towerse/test_tower.py
+++ b/wisdem/test/test_towerse/test_tower.py
@@ -57,7 +57,7 @@ class TestTowerSE(unittest.TestCase):
         # Test land based, 1 material
         self.inputs["water_depth"] = 0.0
         self.inputs["tower_s"] = np.linspace(0, 1, 5)
-        self.inputs["tower_layer_thickness"] = 0.25 * np.ones((1, 4))
+        self.inputs["tower_layer_thickness"] = 0.25 * np.ones((1, 5))
         self.inputs["tower_foundation_height"] = 0.0
         self.inputs["tower_height"] = 1e2
         self.inputs["tower_outer_diameter_in"] = 8 * np.ones(5)
@@ -98,7 +98,7 @@ class TestTowerSE(unittest.TestCase):
         # Test land based, 2 materials
         self.inputs["water_depth"] = 0.0
         self.inputs["tower_s"] = np.linspace(0, 1, 5)
-        self.inputs["tower_layer_thickness"] = np.array([[0.25, 0.25, 0.0, 0.0], [0.0, 0.0, 0.1, 0.1]])
+        self.inputs["tower_layer_thickness"] = np.array([[0.2, 0.2, 0.2, 0.0, 0.0], [0.0, 0.0, 0.0, 0.1, 0.1]])
         self.inputs["tower_foundation_height"] = 0.0
         self.inputs["tower_height"] = 1e2
         self.inputs["tower_outer_diameter_in"] = 8 * np.ones(5)
@@ -122,15 +122,22 @@ class TestTowerSE(unittest.TestCase):
         )
         myobj.compute(self.inputs, self.outputs, self.discrete_inputs, self.discrete_outputs)
 
+        # Define mixtures
+        v = np.r_[np.mean([0.2, 0]), np.mean([0.1, 0.0])]
+        vv = v / v.sum()
+        x = np.r_[1, 2]
+        xx1 = np.sum(x * vv)  # Mass weighted
+        xx2 = 0.5 * np.sum(vv * x) + 0.5 / np.sum(vv / x)  # Volumetric method
+        xx3 = np.sum(x * x * vv) / xx1  # Mass-cost weighted
         npt.assert_equal(self.outputs["tower_section_height"], 25.0 * np.ones(4))
         npt.assert_equal(self.outputs["tower_outer_diameter"], self.inputs["tower_outer_diameter_in"])
-        npt.assert_equal(self.outputs["tower_wall_thickness"], np.array([0.25, 0.25, 0.1, 0.1]))
+        npt.assert_almost_equal(self.outputs["tower_wall_thickness"], np.array([0.2, 0.2, v.sum(), 0.1]))
         npt.assert_equal(self.outputs["outfitting_factor"], 1.1 * np.ones(4))
-        npt.assert_equal(self.outputs["E"], 1e9 * np.array([1, 1, 2, 2]))
-        npt.assert_equal(self.outputs["G"], 1e8 * np.array([1, 1, 2, 2]))
-        npt.assert_equal(self.outputs["sigma_y"], 1e7 * np.array([1, 1, 2, 2]))
-        npt.assert_equal(self.outputs["rho"], 1e4 * np.array([1, 1, 2, 2]))
-        npt.assert_equal(self.outputs["unit_cost"], 1e1 * np.array([1, 1, 2, 2]))
+        npt.assert_almost_equal(self.outputs["E"], 1e9 * np.array([1, 1, xx2, 2]))
+        npt.assert_almost_equal(self.outputs["G"], 1e8 * np.array([1, 1, xx2, 2]))
+        npt.assert_almost_equal(self.outputs["sigma_y"], 1e7 * np.array([1, 1, xx2, 2]))
+        npt.assert_almost_equal(self.outputs["rho"], 1e4 * np.array([1, 1, xx1, 2]))
+        npt.assert_almost_equal(self.outputs["unit_cost"], 1e1 * np.array([1, 1, xx3, 2]))
         npt.assert_equal(self.outputs["z_start"], 0.0)
         npt.assert_equal(self.outputs["transition_piece_height"], 0.0)
         npt.assert_equal(self.outputs["suctionpile_depth"], 0.0)
@@ -138,14 +145,14 @@ class TestTowerSE(unittest.TestCase):
     def testDiscYAML_Monopile_1Material(self):
         self.inputs["water_depth"] = 30.0
         self.inputs["tower_s"] = np.linspace(0, 1, 5)
-        self.inputs["tower_layer_thickness"] = 0.25 * np.ones((1, 4))
+        self.inputs["tower_layer_thickness"] = 0.25 * np.ones((1, 5))
         self.inputs["tower_height"] = 1e2
         self.inputs["tower_foundation_height"] = 10.0
         self.inputs["tower_outer_diameter_in"] = 8 * np.ones(5)
         self.inputs["tower_outfitting_factor"] = 1.1
         self.discrete_inputs["tower_layer_materials"] = ["steel"]
         self.inputs["monopile_s"] = np.linspace(0, 1, 5)
-        self.inputs["monopile_layer_thickness"] = 0.5 * np.ones((1, 4))
+        self.inputs["monopile_layer_thickness"] = 0.5 * np.ones((1, 5))
         self.inputs["monopile_foundation_height"] = -40.0
         self.inputs["monopile_height"] = 50.0
         self.inputs["monopile_outer_diameter_in"] = 10 * np.ones(5)
@@ -179,14 +186,14 @@ class TestTowerSE(unittest.TestCase):
     def testDiscYAML_Monopile_PileShort(self):
         self.inputs["water_depth"] = 60.0
         self.inputs["tower_s"] = np.linspace(0, 1, 5)
-        self.inputs["tower_layer_thickness"] = 0.25 * np.ones((1, 4))
+        self.inputs["tower_layer_thickness"] = 0.25 * np.ones((1, 5))
         self.inputs["tower_height"] = 1e2
         self.inputs["tower_foundation_height"] = 10.0
         self.inputs["tower_outer_diameter_in"] = 8 * np.ones(5)
         self.inputs["tower_outfitting_factor"] = 1.1
         self.discrete_inputs["tower_layer_materials"] = ["steel"]
         self.inputs["monopile_s"] = np.linspace(0, 1, 5)
-        self.inputs["monopile_layer_thickness"] = 0.5 * np.ones((1, 4))
+        self.inputs["monopile_layer_thickness"] = 0.5 * np.ones((1, 5))
         self.inputs["monopile_foundation_height"] = -40.0
         self.inputs["monopile_height"] = 50.0
         self.inputs["monopile_outer_diameter_in"] = 10 * np.ones(5)
@@ -220,14 +227,14 @@ class TestTowerSE(unittest.TestCase):
     def testDiscYAML_Monopile_RedoPileNodes(self):
         self.inputs["water_depth"] = 30.0
         self.inputs["tower_s"] = np.linspace(0, 1, 5)
-        self.inputs["tower_layer_thickness"] = 0.25 * np.ones((1, 4))
+        self.inputs["tower_layer_thickness"] = 0.25 * np.ones((1, 5))
         self.inputs["tower_height"] = 1e2
         self.inputs["tower_foundation_height"] = 10.0
         self.inputs["tower_outer_diameter_in"] = 8 * np.ones(5)
         self.inputs["tower_outfitting_factor"] = 1.1
         self.discrete_inputs["tower_layer_materials"] = ["steel"]
         self.inputs["monopile_s"] = np.linspace(0, 1, 20)
-        self.inputs["monopile_layer_thickness"] = 0.5 * np.ones((1, 19))
+        self.inputs["monopile_layer_thickness"] = 0.5 * np.ones((1, 20))
         self.inputs["monopile_foundation_height"] = -40.0
         self.inputs["monopile_height"] = 50.0
         self.inputs["monopile_outer_diameter_in"] = 10 * np.ones(20)
@@ -265,14 +272,14 @@ class TestTowerSE(unittest.TestCase):
     def testDiscYAML_Monopile_DifferentMaterials(self):
         self.inputs["water_depth"] = 30.0
         self.inputs["tower_s"] = np.linspace(0, 1, 5)
-        self.inputs["tower_layer_thickness"] = 0.25 * np.ones((1, 4))
+        self.inputs["tower_layer_thickness"] = 0.25 * np.ones((1, 5))
         self.inputs["tower_foundation_height"] = 10.0
         self.inputs["tower_height"] = 1e2
         self.inputs["tower_outer_diameter_in"] = 8 * np.ones(5)
         self.inputs["tower_outfitting_factor"] = 1.1
         self.discrete_inputs["tower_layer_materials"] = ["steel"]
         self.inputs["monopile_s"] = np.linspace(0, 1, 5)
-        self.inputs["monopile_layer_thickness"] = 0.5 * np.ones((1, 4))
+        self.inputs["monopile_layer_thickness"] = 0.5 * np.ones((1, 5))
         self.inputs["monopile_foundation_height"] = -40.0
         self.inputs["monopile_height"] = 50.0
         self.inputs["monopile_outer_diameter_in"] = 10 * np.ones(5)
@@ -306,7 +313,7 @@ class TestTowerSE(unittest.TestCase):
     def testDiscYAML_Bad_Inputs(self):
         self.inputs["water_depth"] = 0.0
         self.inputs["tower_s"] = np.linspace(0, 1, 5)
-        self.inputs["tower_layer_thickness"] = 0.25 * np.ones((1, 4))
+        self.inputs["tower_layer_thickness"] = 0.25 * np.ones((1, 5))
         self.inputs["tower_foundation_height"] = 0.0
         self.inputs["tower_height"] = 1e2
         self.inputs["tower_outer_diameter_in"] = 8 * np.ones(5)
@@ -330,14 +337,14 @@ class TestTowerSE(unittest.TestCase):
         )
 
         try:
-            self.inputs["tower_layer_thickness"][0, -1] = 0.0
+            self.inputs["tower_layer_thickness"][0, -2:] = 0.0
             myobj.compute(self.inputs, self.outputs, self.discrete_inputs, self.discrete_outputs)
             self.assertTrue(False)  # Shouldn't get here
         except ValueError:
             self.assertTrue(True)
 
         try:
-            self.inputs["tower_layer_thickness"][0, -1] = 0.25
+            self.inputs["tower_layer_thickness"][0, -2:] = 0.25
             self.inputs["tower_outer_diameter_in"][-1] = -1.0
             myobj.compute(self.inputs, self.outputs, self.discrete_inputs, self.discrete_outputs)
             self.assertTrue(False)  # Shouldn't get here
@@ -345,7 +352,7 @@ class TestTowerSE(unittest.TestCase):
             self.assertTrue(True)
 
         try:
-            self.inputs["tower_layer_thickness"][0, -1] = 0.25
+            self.inputs["tower_layer_thickness"][0, -2:] = 0.25
             self.inputs["tower_outer_diameter_in"][-1] = 8.0
             self.inputs["tower_s"][-1] = self.inputs["tower_s"][-2]
             myobj.compute(self.inputs, self.outputs, self.discrete_inputs, self.discrete_outputs)
@@ -561,7 +568,7 @@ class TestTowerSE(unittest.TestCase):
         prob["tower_height"] = 80.0
         # prob['tower_section_height'] = 40.0*np.ones(2)
         prob["tower_outer_diameter_in"] = 10.0 * np.ones(3)
-        prob["tower_layer_thickness"] = 0.1 * np.ones(2).reshape((1, 2))
+        prob["tower_layer_thickness"] = 0.1 * np.ones((1, 3))
         prob["tower_outfitting_factor"] = 1.0
         prob["tower_layer_materials"] = ["steel"]
         prob["material_names"] = ["steel"]
@@ -664,14 +671,14 @@ class TestTowerSE(unittest.TestCase):
         prob["tower_foundation_height"] = 0.0
         prob["tower_height"] = 60.0
         prob["tower_outer_diameter_in"] = 10.0 * np.ones(3)
-        prob["tower_layer_thickness"] = 0.1 * np.ones(2).reshape((1, 2))
+        prob["tower_layer_thickness"] = 0.1 * np.ones((1, 3))
         prob["tower_outfitting_factor"] = 1.0
         hval = np.array([15.0, 30.0])
         prob["monopile_s"] = np.cumsum(np.r_[0, hval]) / hval.sum()
         prob["monopile_foundation_height"] = -45.0
         prob["monopile_height"] = hval.sum()
         prob["monopile_outer_diameter_in"] = 10.0 * np.ones(3)
-        prob["monopile_layer_thickness"] = 0.1 * np.ones(2).reshape((1, 2))
+        prob["monopile_layer_thickness"] = 0.1 * np.ones((1, 3))
         prob["monopile_outfitting_factor"] = 1.0
         prob["tower_layer_materials"] = prob["monopile_layer_materials"] = ["steel"]
         prob["material_names"] = ["steel"]
@@ -771,9 +778,9 @@ class TestTowerSE(unittest.TestCase):
         npt.assert_equal(prob["pre.Myy"], np.array([3e4]))
         npt.assert_equal(prob["pre.Mzz"], np.array([4e4]))
 
-        npt.assert_almost_equal(prob["tower.base_F"], [3.86908254e+04 , 1.70778509e+03, -3.39826364e+07], 0)
+        npt.assert_almost_equal(prob["tower.base_F"], [3.86908254e04, 1.70778509e03, -3.39826364e07], 0)
         npt.assert_almost_equal(prob["tower.base_M"], [-294477.83027742, -2732413.3684214, 40000.0], 0)
-        
+
     def testAddedMassForces(self):
         self.modeling_options["TowerSE"]["n_height_monopile"] = 3
         self.modeling_options["TowerSE"]["n_layers_monopile"] = 1
@@ -793,14 +800,14 @@ class TestTowerSE(unittest.TestCase):
         prob["tower_foundation_height"] = 0.0
         prob["tower_height"] = 60.0
         prob["tower_outer_diameter_in"] = 10.0 * np.ones(3)
-        prob["tower_layer_thickness"] = 0.1 * np.ones(2).reshape((1, 2))
+        prob["tower_layer_thickness"] = 0.1 * np.ones((1, 3))
         prob["tower_outfitting_factor"] = 1.0
         hval = np.array([15.0, 30.0])
         prob["monopile_s"] = np.cumsum(np.r_[0, hval]) / hval.sum()
         prob["monopile_foundation_height"] = -45.0
         prob["monopile_height"] = hval.sum()
         prob["monopile_outer_diameter_in"] = 10.0 * np.ones(3)
-        prob["monopile_layer_thickness"] = 0.1 * np.ones(2).reshape((1, 2))
+        prob["monopile_layer_thickness"] = 0.1 * np.ones((1, 3))
         prob["monopile_outfitting_factor"] = 1.0
         prob["tower_layer_materials"] = prob["monopile_layer_materials"] = ["steel"]
         prob["material_names"] = ["steel"]
@@ -893,6 +900,7 @@ class TestTowerSE(unittest.TestCase):
         t_param = np.array(
             [
                 0.05534138,
+                0.05534138,
                 0.05344902,
                 0.05150928,
                 0.04952705,
@@ -980,7 +988,7 @@ class TestTowerSE(unittest.TestCase):
         # --- geometry ----
         h_param = np.diff(np.array([0.0, 43.8, 87.6]))
         d_param = np.array([6.0, 4.935, 3.87])
-        t_param = 1.3 * np.array([0.025, 0.021])
+        t_param = 1.3 * np.array([0.027, 0.023, 0.019])
         z_foundation = 0.0
         yaw = 0.0
         Koutfitting = 1.07
@@ -1162,14 +1170,14 @@ class TestTowerSE(unittest.TestCase):
         npt.assert_almost_equal(
             prob["post2.shell_buckling"], [0.31204018, 0.22828066, 0.14756271, 0.12234901, 0.03991668, 0.02701307]
         )
-        npt.assert_almost_equal(prob["tower1.base_F"][0], 1300347.476206353, 2) #1.29980269e06, 2)
+        npt.assert_almost_equal(prob["tower1.base_F"][0], 1300347.476206353, 2)  # 1.29980269e06, 2)
         npt.assert_array_less(np.abs(prob["tower1.base_F"][1]), 1e2, 2)
         npt.assert_almost_equal(prob["tower1.base_F"][2], -6.31005811e06, 2)
-        npt.assert_almost_equal(prob["tower1.base_M"], [4.14775052e+06, 1.10758024e+08, -3.46827499e+05], 0)
+        npt.assert_almost_equal(prob["tower1.base_M"], [4.14775052e06, 1.10758024e08, -3.46827499e05], 0)
         npt.assert_almost_equal(prob["tower2.base_F"][0], 1617231.046083178, 2)
         npt.assert_array_less(np.abs(prob["tower2.base_F"][1]), 1e2, 2)
         npt.assert_almost_equal(prob["tower2.base_F"][2], -6.27903939e06, 2)
-        npt.assert_almost_equal(prob["tower2.base_M"], [-1.76120197e+06, 1.12569564e+08, 1.47321336e+05], 0)
+        npt.assert_almost_equal(prob["tower2.base_M"], [-1.76120197e06, 1.12569564e08, 1.47321336e05], 0)
 
 
 def suite():


### PR DESCRIPTION
## Purpose
This will enable more seamless read and write of the tower grid to the yaml files while leaving all discretization complexity within TowerSE.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation