### PR TITLE
B/twist inverse

### DIFF
--- a/docs/inputs/analysis_schema.rst
+++ b/docs/inputs/analysis_schema.rst
@@ -90,7 +90,10 @@ Blade twist as a design variable by adding or subtracting radians from the initi
     *Default* = False
 
 :code:`inverse` : Boolean
-    Words TODO?
+    When set to True, the twist is defined inverting the 
+    blade-element momentum equations to achieve a desired margin to stall, 
+    which is defined among the constraints.
+    :code:`flag` and :code:`inverse` cannot be simultaneously be set to True
 
     *Default* = False
 
@@ -172,7 +175,8 @@ Adjust airfoil positions along the blade span.
 
 :code:`af_start` : Integer
     Index of airfoil where the optimization can start shifting airfoil
-    position. The airfoil at blade tip is always locked.
+    position. The airfoil at blade tip is always locked. It is advised 
+    to keep the airfoils close to blade root locked.
 
     *Default* = 4
 

--- a/examples/02_reference_turbines/IEA-15-240-RWT.yaml
+++ b/examples/02_reference_turbines/IEA-15-240-RWT.yaml
@@ -347,7 +347,7 @@ components:
         spinner_material: glass_uni
     nacelle:
         drivetrain:
-            uptilt_angle: 0.10471975511965977 # 6 deg
+            uptilt: 0.10471975511965977 # 6 deg
             distance_tt_hub: 5.614
             overhang: 12.0313
             drag_coefficient: 0.5

--- a/examples/02_reference_turbines/IEA-3p4-130-RWT.yaml
+++ b/examples/02_reference_turbines/IEA-3p4-130-RWT.yaml
@@ -280,7 +280,7 @@ components:
     nacelle:
         drivetrain:
             diameter: 3.0
-            uptilt_angle: 0.08726 # 5 deg
+            uptilt: 0.08726 # 5 deg
             distance_tt_hub: 2.
             distance_hub2mb: 1.912
             distance_mb2mb: 0.368

--- a/examples/02_reference_turbines/nrel5mw.yaml
+++ b/examples/02_reference_turbines/nrel5mw.yaml
@@ -196,7 +196,7 @@ components:
     nacelle:
         drivetrain:
             diameter: 3.0
-            uptilt_angle: 0.08726
+            uptilt: 0.08726
             distance_tt_hub: 2.3
             distance_hub2mb: 1.912
             distance_mb2mb: 0.368

--- a/examples/03_blade/blade.yaml
+++ b/examples/03_blade/blade.yaml
@@ -338,7 +338,7 @@ components:
     nacelle:
         drivetrain:
             diameter: 3.0
-            uptilt_angle: 0.10471975511965977 # 6 deg
+            uptilt: 0.10471975511965977 # 6 deg
             distance_tt_hub: 3.0
             distance_hub2mb: 1.912
             distance_mb2mb: 0.368

--- a/examples/09_weis_floating/nrel5mw-semi_oc4.yaml
+++ b/examples/09_weis_floating/nrel5mw-semi_oc4.yaml
@@ -197,7 +197,7 @@ components:
     nacelle:
         drivetrain:
             diameter: 3.0
-            uptilt_angle: 0.08726
+            uptilt: 0.08726
             distance_tt_hub: 2.3
             distance_hub2mb: 1.912
             distance_mb2mb: 0.368

--- a/examples/09_weis_floating/nrel5mw-spar_oc3.yaml
+++ b/examples/09_weis_floating/nrel5mw-spar_oc3.yaml
@@ -197,7 +197,7 @@ components:
     nacelle:
         drivetrain:
             diameter: 3.0
-            uptilt_angle: 0.08726
+            uptilt: 0.08726
             distance_tt_hub: 2.3
             distance_hub2mb: 1.912
             distance_mb2mb: 0.368

--- a/wisdem/ccblade/ccblade_component.py
+++ b/wisdem/ccblade/ccblade_component.py
@@ -3,6 +3,7 @@ from openmdao.api import ExplicitComponent
 import numpy as np
 import wisdem.ccblade._bem as _bem
 from wisdem.commonse.csystem import DirectionVector
+from scipy.interpolate import PchipInterpolator
 
 
 cosd = lambda x: np.cos(np.deg2rad(x))

--- a/wisdem/ccblade/ccblade_component.py
+++ b/wisdem/ccblade/ccblade_component.py
@@ -533,6 +533,8 @@ class CCBladeTwist(ExplicitComponent):
                 )
 
         if self.options["opt_options"]["design_variables"]["blade"]["aero_shape"]["twist"]["inverse"]:
+            if self.options["opt_options"]["design_variables"]["blade"]["aero_shape"]["twist"]["flag"]:
+                raise Exception("Twist cannot be simultaneously optimized and set to be defined inverting the BEM equations. Please check your analysis options yaml.")
             # Find cl and cd for max efficiency
             cl = np.zeros(self.n_span)
             cd = np.zeros(self.n_span)

--- a/wisdem/glue_code/gc_WT_InitModel.py
+++ b/wisdem/glue_code/gc_WT_InitModel.py
@@ -599,7 +599,7 @@ def assign_hub_values(wt_opt, hub):
 
 def assign_nacelle_values(wt_opt, modeling_options, nacelle):
     # Common direct and geared
-    wt_opt["nacelle.uptilt"] = nacelle["drivetrain"]["uptilt_angle"]
+    wt_opt["nacelle.uptilt"] = nacelle["drivetrain"]["uptilt"]
     wt_opt["nacelle.distance_tt_hub"] = nacelle["drivetrain"]["distance_tt_hub"]
     wt_opt["nacelle.overhang"] = nacelle["drivetrain"]["overhang"]
     wt_opt["nacelle.distance_hub2mb"] = nacelle["drivetrain"]["distance_hub_mb"]


### PR DESCRIPTION
This is a little PR to fix two little bugs in wisdem:
1) The inverse flag to determine twist given a desired margin to stall had not been maintained and it is now restored. Docs are also updated
2) The geometry yaml duplicated the key up tilt and uptilt_angle

## Purpose
Fix bugs

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Tests are passing

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [x] I have added necessary documentation