### PR TITLE
fix connections blade twist

### DIFF
--- a/wisdem/glue_code/gc_LoadInputs.py
+++ b/wisdem/glue_code/gc_LoadInputs.py
@@ -963,7 +963,7 @@ class WindTurbineOntologyPython(object):
 
         # Update controller
         if self.modeling_options["flags"]["control"]:
-            self.wt_init["control"]["tsr"] = float(wt_opt["control.rated_TSR"])
+            self.wt_init["control"]["torque"]["tsr"] = float(wt_opt["control.rated_TSR"])
 
         # Write yamls with updated values
         sch.write_geometry_yaml(self.wt_init, fname_output)

--- a/wisdem/glue_code/glue_code.py
+++ b/wisdem/glue_code/glue_code.py
@@ -100,12 +100,11 @@ class WT_RNTA(om.Group):
             self.connect("configuration.ws_class", "wt_class.turbine_class")
 
             # Connections from blade aero parametrization to other modules
-            self.connect("blade.pa.twist_param", ["re.theta", "rs.theta"])
-            # self.connect('blade.pa.twist_param',            'rs.tip_pos.theta_tip',   src_indices=[-1])
+            self.connect("ccblade.theta", ["re.theta", "rs.theta"])
             self.connect("blade.pa.chord_param", "re.chord")
             self.connect("blade.pa.chord_param", ["rs.chord"])
             if modeling_options["flags"]["blade"]:
-                self.connect("blade.pa.twist_param", "rp.theta")
+                self.connect("ccblade.theta", "rp.theta")
                 self.connect("blade.pa.chord_param", "rp.chord")
             self.connect("configuration.n_blades", "rs.constr.blade_number")
 
@@ -176,8 +175,6 @@ class WT_RNTA(om.Group):
                 self.connect("drivese.lss_rpm", "rp.powercurve.lss_rpm")
                 self.connect("drivese.generator_efficiency", "rp.powercurve.generator_efficiency")
             self.connect("assembly.r_blade", "rp.r")
-            # self.connect('blade.pa.chord_param',           'rp.chord')
-            # self.connect('blade.pa.twist_param',           'rp.theta')
             self.connect("hub.radius", "rp.Rhub")
             self.connect("assembly.rotor_radius", "rp.Rtip")
             self.connect("assembly.hub_height", "rp.hub_height")

--- a/wisdem/inputs/modeling_schema.yaml
+++ b/wisdem/inputs/modeling_schema.yaml
@@ -76,7 +76,7 @@ properties:
                 description: Number of wind speeds to determine the Cp-Ct-Cq-surfaces
             regulation_reg_III:
                 type: boolean
-                default: False
+                default: True
                 description: Flag to derive the regulation trajectory in region III in terms of pitch and TSR
             spar_cap_ss:
                 type: string


### PR DESCRIPTION
The component running a single instance of CCBlade and optionally used to determine the twist by inverting the bem equations was not properly connected and the twist was not passed out correctly

## Purpose
Re-instate the ability to determine twist from inverted beam equations

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation