### PR TITLE
B/mode shapes

### DIFF
--- a/wisdem/commonse/utilities.py
+++ b/wisdem/commonse/utilities.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 
 import numpy as np
 from scipy.linalg import solve_banded
+from scipy.optimize import curve_fit
 
 
 def mode_fit(x, c2, c3, c4, c5, c6):
@@ -20,15 +21,17 @@ def get_modal_coefficients(x, y, deg=6):
     xn = (x - x.min()) / (x.max() - x.min())
 
     # Get coefficients to 6th order polynomial
-    p6 = np.polynomial.polynomial.polyfit(xn, y, deg)
-    # coef, pcov = curve_fit(mode_fit, xn, y)
+    # NOTE: POLYFIT does not give the correct modal settings.  Have to use curve_fit
+    # p6 = np.polynomial.polynomial.polyfit(xn, y, deg)
 
     # Normalize for Elastodyn
     if y.ndim > 1:
-        p6 = p6[2:, :]
+        p6 = np.zeros((5, y.shape[1]))
+        for k in range(y.shape[1]):
+            p6[:, k], _ = curve_fit(mode_fit, xn, y[:, k])
         p6 /= p6.sum(axis=0)[np.newaxis, :]
     else:
-        p6 = p6[2:]
+        p6, _ = curve_fit(mode_fit, xn, y)
         p6 /= p6.sum()
 
     return p6

--- a/wisdem/test/test_commonse/test_utilities.py
+++ b/wisdem/test/test_commonse/test_utilities.py
@@ -26,6 +26,7 @@ class TestAny(unittest.TestCase):
     def testModalCoefficients(self):
         # Test exact 6-deg polynomial
         p = np.random.random((7,))
+        p[:2] = 0.0
         x = np.linspace(0, 1)
         y = np.polynomial.polynomial.polyval(x, p)
 


### PR DESCRIPTION
## Purpose
The polyfit approach to finding the mode shapes turned out to be incompatible with ElastoDyn.  Reverting back to the method Evan Gaertner used for the non-linear least-squares curve fit.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

- [x] I have run existing tests which pass locally with my changes
- [x] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation