### PR TITLE
F/dv indices

### DIFF
--- a/docs/inputs/analysis_schema.rst
+++ b/docs/inputs/analysis_schema.rst
@@ -99,9 +99,7 @@ Blade twist as a design variable by adding or subtracting radians from the initi
 
 :code:`n_opt` : Integer
     Number of equally-spaced control points of the spline
-    parametrizing the twist distribution along blade span. By default,
-    the first two points are locked to prevent the optimizer to try to
-    optimize the twist of the blade root cylinder.
+    parametrizing the twist distribution along blade span. 
 
     *Default* = 8
 
@@ -119,6 +117,17 @@ Blade twist as a design variable by adding or subtracting radians from the initi
 
     *Default* = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
 
+:code:`lock_root` : Integer
+    Integer setting how many DVs along span are locked starting from blade root.
+    By default, the first two points are locked to prevent the optimizer to try to
+    optimize the twist of the blade root cylinder.
+
+    *Default* = 2
+
+:code:`lock_tip` : Integer
+    Integer setting how many DVs along span are locked starting from blade tip.
+
+    *Default* = 0
 
 
 chord
@@ -134,15 +143,7 @@ Blade chord as a design variable by scaling (multiplying) the initial value at s
 
 :code:`n_opt` : Integer
     Number of equally-spaced control points of the spline
-    parametrizing the chord distribution along blade span. By default,
-    the first two points close to blade root and the last point are
-    locked. The first two points impact the diameter of the blade root
-    cylinder, and the models implemented in WISDEM do not have the
-    level of fidelity to appropriately size the blade root diameter.
-    The last point controls the chord length at blade tip and due to
-    the imperfect tip loss models of CCBlade, it is usually a good
-    idea to taper the chord manually and do not let a numerical
-    optimizer control it.
+    parametrizing the chord distribution along blade span.
 
     *Default* = 8
 
@@ -160,6 +161,23 @@ Blade chord as a design variable by scaling (multiplying) the initial value at s
 
     *Default* = 1.5
 
+:code:`lock_root` : Integer
+    Integer setting how many DVs along span are locked starting from blade root.
+    By default, the first two points close to blade root are
+    locked. The first two points impact the diameter of the blade root
+    cylinder, and the models implemented in WISDEM do not have the
+    level of fidelity to appropriately size the blade root diameter.
+
+    *Default* = 2
+
+:code:`lock_tip` : Integer
+    Integer setting how many DVs along span are locked starting from blade tip.
+    The last point controls the chord length at blade tip and due to
+    the imperfect tip loss models of CCBlade, it is usually a good
+    idea to taper the chord manually and do not let a numerical
+    optimizer control it. The default is therefore set to 1.
+
+    *Default* = 1
 
 
 af_positions
@@ -206,10 +224,6 @@ Blade suction-side spar cap thickness as a design variable by scaling (multiplyi
 :code:`n_opt` : Integer
     Number of equally-spaced control points of the spline
     parametrizing the thickness of the spar cap on the suction side.
-    By default, the first point close to blade root and the last point
-    close to blade tip are locked. This is done to impose a pre-
-    defined taper to small thicknesses and mimic a blade
-    manufacturability constraint.
 
     *Default* = 8
 
@@ -227,6 +241,23 @@ Blade suction-side spar cap thickness as a design variable by scaling (multiplyi
 
     *Default* = 1.5
 
+:code:`lock_root` : Integer
+    Integer setting how many DVs along span are locked starting from blade root.
+    By default, the first point close to blade root is locked. 
+    This is done to impose a pre-
+    defined taper to small thicknesses and mimic a blade
+    manufacturability constraint.
+
+    *Default* = 1
+
+:code:`lock_tip` : Integer
+    Integer setting how many DVs along span are locked starting from blade tip.
+    By default, the last point close to blade tip is locked. 
+    This is done to impose a pre-
+    defined taper to small thicknesses and mimic a blade
+    manufacturability constraint.
+
+    *Default* = 1
 
 
 spar_cap_ps
@@ -243,10 +274,6 @@ Blade pressure-side spar cap thickness as a design variable by scaling (multiply
 :code:`n_opt` : Integer
     Number of equally-spaced control points of the spline
     parametrizing the thickness of the spar cap on the pressure side.
-    By default, the first point close to blade root and the last point
-    close to blade tip are locked. This is done to impose a pre-
-    defined taper to small thicknesses and mimic a blade
-    manufacturability constraint.
 
     *Default* = 8
 
@@ -264,6 +291,23 @@ Blade pressure-side spar cap thickness as a design variable by scaling (multiply
 
     *Default* = 1.5
 
+:code:`lock_root` : Integer
+    Integer setting how many DVs along span are locked starting from blade root.
+    By default, the first point close to blade root is locked. 
+    This is done to impose a pre-
+    defined taper to small thicknesses and mimic a blade
+    manufacturability constraint.
+
+    *Default* = 1
+
+:code:`lock_tip` : Integer
+    Integer setting how many DVs along span are locked starting from blade tip.
+    By default, the last point close to blade tip is locked. 
+    This is done to impose a pre-
+    defined taper to small thicknesses and mimic a blade
+    manufacturability constraint.
+
+    *Default* = 1
 
 
 te_ss

--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -23,12 +23,12 @@ class PoseOptimization(object):
         if rotorD_opt["flag"]:
             n_DV += 1
         if blade_opt["aero_shape"]["twist"]["flag"]:
-            n_DV += blade_opt["aero_shape"]["twist"]["n_opt"] - 
-                    (blade_opt["aero_shape"]["twist"]["lock_root"] +
+            n_DV += blade_opt["aero_shape"]["twist"]["n_opt"] - (
+                    blade_opt["aero_shape"]["twist"]["lock_root"] + 
                     blade_opt["aero_shape"]["twist"]["lock_tip"])
         if blade_opt["aero_shape"]["chord"]["flag"]:
-            n_DV += blade_opt["aero_shape"]["chord"]["n_opt"] - 
-                    (blade_opt["aero_shape"]["chord"]["lock_root"] +
+            n_DV += blade_opt["aero_shape"]["chord"]["n_opt"] - (
+                    blade_opt["aero_shape"]["chord"]["lock_root"] +
                     blade_opt["aero_shape"]["chord"]["lock_tip"])
         if blade_opt["aero_shape"]["af_positions"]["flag"]:
             n_DV += (
@@ -37,15 +37,15 @@ class PoseOptimization(object):
                 - 1
             )
         if blade_opt["structure"]["spar_cap_ss"]["flag"]:
-            n_DV += blade_opt["structure"]["spar_cap_ss"]["n_opt"] - 
-                    (blade_opt["aero_shape"]["spar_cap_ss"]["lock_root"] +
+            n_DV += blade_opt["structure"]["spar_cap_ss"]["n_opt"] - (
+                    blade_opt["aero_shape"]["spar_cap_ss"]["lock_root"] +
                     blade_opt["aero_shape"]["spar_cap_ss"]["lock_tip"])
         if (
             blade_opt["structure"]["spar_cap_ps"]["flag"]
             and not blade_opt["structure"]["spar_cap_ps"]["equal_to_suction"]
         ):
-            n_DV += blade_opt["structure"]["spar_cap_ps"]["n_opt"] - 
-                    (blade_opt["aero_shape"]["spar_cap_ps"]["lock_root"] +
+            n_DV += blade_opt["structure"]["spar_cap_ps"]["n_opt"] - (
+                    blade_opt["aero_shape"]["spar_cap_ps"]["lock_root"] +
                     blade_opt["aero_shape"]["spar_cap_ps"]["lock_tip"])
         if self.opt["design_variables"]["control"]["tsr"]["flag"]:
             n_DV += 1

--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -23,9 +23,13 @@ class PoseOptimization(object):
         if rotorD_opt["flag"]:
             n_DV += 1
         if blade_opt["aero_shape"]["twist"]["flag"]:
-            n_DV += blade_opt["aero_shape"]["twist"]["n_opt"] - 2
+            n_DV += blade_opt["aero_shape"]["twist"]["n_opt"] - 
+                    (blade_opt["aero_shape"]["twist"]["lock_root"] +
+                    blade_opt["aero_shape"]["twist"]["lock_tip"])
         if blade_opt["aero_shape"]["chord"]["flag"]:
-            n_DV += blade_opt["aero_shape"]["chord"]["n_opt"] - 3
+            n_DV += blade_opt["aero_shape"]["chord"]["n_opt"] - 
+                    (blade_opt["aero_shape"]["chord"]["lock_root"] +
+                    blade_opt["aero_shape"]["chord"]["lock_tip"])
         if blade_opt["aero_shape"]["af_positions"]["flag"]:
             n_DV += (
                 self.modeling["WISDEM"]["RotorSE"]["n_af_span"]
@@ -33,12 +37,16 @@ class PoseOptimization(object):
                 - 1
             )
         if blade_opt["structure"]["spar_cap_ss"]["flag"]:
-            n_DV += blade_opt["structure"]["spar_cap_ss"]["n_opt"] - 2
+            n_DV += blade_opt["structure"]["spar_cap_ss"]["n_opt"] - 
+                    (blade_opt["aero_shape"]["spar_cap_ss"]["lock_root"] +
+                    blade_opt["aero_shape"]["spar_cap_ss"]["lock_tip"])
         if (
             blade_opt["structure"]["spar_cap_ps"]["flag"]
             and not blade_opt["structure"]["spar_cap_ps"]["equal_to_suction"]
         ):
-            n_DV += blade_opt["structure"]["spar_cap_ps"]["n_opt"] - 2
+            n_DV += blade_opt["structure"]["spar_cap_ps"]["n_opt"] - 
+                    (blade_opt["aero_shape"]["spar_cap_ps"]["lock_root"] +
+                    blade_opt["aero_shape"]["spar_cap_ps"]["lock_tip"])
         if self.opt["design_variables"]["control"]["tsr"]["flag"]:
             n_DV += 1
         # if self.opt["design_variables"]["control"]["servo"]["pitch_control"]["flag"]:
@@ -250,13 +258,18 @@ class PoseOptimization(object):
                 "configuration.rotor_diameter_user", lower=rotorD_opt["minimum"], upper=rotorD_opt["minimum"], ref=1.0e2
             )
 
-        if blade_opt["aero_shape"]["twist"]["flag"]:
-            indices = range(2, blade_opt["aero_shape"]["twist"]["n_opt"])
+        twist_options = blade_opt["aero_shape"]["twist"]
+        if twist_options["flag"]:
+            indices = range(twist_options["lock_root"],
+                            twist_options["n_opt"] - 
+                            twist_options["lock_tip"])
             wt_opt.model.add_design_var("blade.opt_var.twist_opt_gain", indices=indices, lower=0.0, upper=1.0)
 
         chord_options = blade_opt["aero_shape"]["chord"]
         if chord_options["flag"]:
-            indices = range(3, chord_options["n_opt"] - 1)
+            indices = range(chord_options["lock_root"],
+                            chord_options["n_opt"]["n_opt"] - 
+                            chord_options["lock_tip"])
             wt_opt.model.add_design_var(
                 "blade.opt_var.chord_opt_gain",
                 indices=indices,
@@ -283,7 +296,9 @@ class PoseOptimization(object):
 
         spar_cap_ss_options = blade_opt["structure"]["spar_cap_ss"]
         if spar_cap_ss_options["flag"]:
-            indices = range(1, spar_cap_ss_options["n_opt"] - 1)
+            indices = range(spar_cap_ss_options["lock_root"],
+                            spar_cap_ss_options["n_opt"]["n_opt"] - 
+                            spar_cap_ss_options["lock_tip"])
             wt_opt.model.add_design_var(
                 "blade.opt_var.spar_cap_ss_opt_gain",
                 indices=indices,
@@ -295,7 +310,9 @@ class PoseOptimization(object):
         # `equal_to_suction` as False in the optimization yaml.
         spar_cap_ps_options = blade_opt["structure"]["spar_cap_ps"]
         if spar_cap_ps_options["flag"] and not spar_cap_ps_options["equal_to_suction"]:
-            indices = range(1, spar_cap_ps_options["n_opt"] - 1)
+            indices = range(spar_cap_ps_options["lock_root"],
+                            spar_cap_ps_options["n_opt"]["n_opt"] - 
+                            spar_cap_ps_options["lock_tip"])
             wt_opt.model.add_design_var(
                 "blade.opt_var.spar_cap_ps_opt_gain",
                 indices=indices,

--- a/wisdem/inputs/analysis_schema.yaml
+++ b/wisdem/inputs/analysis_schema.yaml
@@ -81,6 +81,14 @@ properties:
                                         items:
                                             type: number
                                             unit: rad
+                                    lock_root:
+                                        type: integer
+                                        default: 2
+                                        description: How many DVs along span are locked starting from blade root
+                                    lock_tip:
+                                        type: integer
+                                        default: 0
+                                        description: How many DVs along span are locked starting from blade tip
                             chord:
                                 type: object
                                 default: {}
@@ -102,6 +110,14 @@ properties:
                                         default: 1.5
                                         unit: none
                                         description: Upper bound on scalar multiplier that will be applied to value at control points
+                                    lock_root:
+                                        type: integer
+                                        default: 2
+                                        description: How many DVs along span are locked starting from blade root
+                                    lock_tip:
+                                        type: integer
+                                        default: 1
+                                        description: How many DVs along span are locked starting from blade tip
                             af_positions:
                                 type: object
                                 default: {}
@@ -131,6 +147,14 @@ properties:
                                         description: Number of equally-spaced control points of the spline parametrizing the thickness of the spar cap on the suction side. By default, the first point close to blade root and the last point close to blade tip are locked. This is done to impose a pre-defined taper to small thicknesses and mimic a blade manufacturability constraint.
                                     min_gain: *mingain
                                     max_gain: *maxgain
+                                    lock_root:
+                                        type: integer
+                                        default: 1
+                                        description: How many DVs along span are locked starting from blade root
+                                    lock_tip:
+                                        type: integer
+                                        default: 1
+                                        description: How many DVs along span are locked starting from blade tip
                             spar_cap_ps:
                                 type: object
                                 description: Blade pressure-side spar cap thickness as a design variable by scaling (multiplying) the initial value at spline control points along the span.
@@ -148,6 +172,14 @@ properties:
                                         description: Number of equally-spaced control points of the spline parametrizing the thickness of the spar cap on the pressure side. By default, the first point close to blade root and the last point close to blade tip are locked. This is done to impose a pre-defined taper to small thicknesses and mimic a blade manufacturability constraint.
                                     min_gain: *mingain
                                     max_gain: *maxgain
+                                    lock_root:
+                                        type: integer
+                                        default: 1
+                                        description: How many DVs along span are locked starting from blade root
+                                    lock_tip:
+                                        type: integer
+                                        default: 1
+                                        description: How many DVs along span are locked starting from blade tip
                             te_ss:
                                 type: object
                                 default: {}
@@ -789,93 +821,44 @@ properties:
 
     driver:
         type: object
+        description: Specification of the optimization driver (optimization algorithm) parameters
         default: {}
         properties:
-            optimization:
-                type: object
-                description: Specification of the optimization driver (optimization algorithm) parameters
-                default: {}
-                properties:
-                    flag: *flag
-                    tol:
-                        type: number
-                        description: Convergence tolerance (relative)
-                        default: 1e-6
-                        minimum: 1e-12
-                        maximum: 1.0
-                        unit: none
-                    max_iter:
-                        type: integer
-                        description: Max number of optimization iterations
-                        default: 100
-                        minimum: 0
-                        maximum: 100000
-                    max_function_calls:
-                        type: integer
-                        description: Max number of calls to objective function evaluation
-                        default: 100000
-                        minimum: 0
-                        maximum: 100000000
-                    solver:
-                        type: string
-                        description: Optimization driver.  Can be one of [SLSQP, CONMIN, COBYLA, SNOPT]
-                        default: SLSQP
-                        enum: [SLSQP, CONMIN, COBYLA, SNOPT]
-                    step_size:
-                        type: number
-                        description: Maximum step size
-                        default: 1e-3
-                        minimum: 1e-10
-                        maximum: 100.0
-                    form:
-                        type: string
-                        description: Finite difference calculation mode
-                        default: central
-                        enum: [central, forward, complex]
-            design_of_experiments:
-                type: object
-                description: Specification of the design of experiments driver parameters
-                default: {}
-                properties:
-                    flag: *flag
-                    run_parallel:
-                        type: boolean
-                        default: True
-                        description: Toggle parallel model runs
-                    generator:
-                        type: string
-                        description: Type of model input generator. 
-                        default: Uniform
-                        enum: [Uniform, FullFact, PlackettBurman, BoxBehnken, LatinHypercube]
-                    num_samples:
-                        type: integer
-                        description: Number of samples to evaluate model at (Uniform and LatinHypercube only)
-                        default: 5
-                        minimum: 1
-                        maximum: 1000000
-                    seed: 
-                        type: integer
-                        description: Random seed to use if design is randomized 
-                        default: 2
-                        minimum: 1
-                        maximum: 1000000
-                    levels:
-                        type: integer
-                        description: Number of evenly spaced levels between each design variable lower and upper bound (FullFactorial only)
-                        default: 2
-                        minimum: 1
-                        maximum: 1000000
-                    criterion: 
-                        type: string
-                        description: Descriptor of sampling method for LatinHypercube generator
-                        default: None
-                        enum: [None, center, c, maximin, m, centermaximin, cm, correelation, corr]
-                    iterations: 
-                        type: integer
-                        description: Number of iterations in maximin and correlations algorithms (LatinHypercube only)
-                        default: 2
-                        minimum: 1
-                        maximum: 1000000
+            tol:
+                type: number
+                description: Convergence tolerance (relative)
+                default: 1e-6
+                minimum: 1e-12
+                maximum: 1.0
+                unit: none
+            max_iter:
+                type: integer
+                description: Max number of optimization iterations
+                default: 100
+                minimum: 0
+                maximum: 100000
+            max_function_calls:
+                type: integer
+                description: Max number of calls to objective function evaluation
+                default: 100000
+                minimum: 0
+                maximum: 100000000
+            solver:
+                type: string
+                description: Optimization driver.  Can be one of [SLSQP, CONMIN, COBYLA, SNOPT]
+                default: SLSQP
+                enum: [SLSQP, CONMIN, COBYLA, SNOPT]
+            step_size:
+                type: number
+                description: Maximum step size
+                default: 1e-3
+                minimum: 1e-10
+                maximum: 100.0
+            form:
+                type: string
+                description: Finite difference calculation mode
+                default: central
+                enum: [central, forward, complex]
 
     recorder:
         type: object


### PR DESCRIPTION
This PR removes the hard coded indices from the pose_optimization.py script, introducing indexes in the analysis schema to lock a user-defined number of DVs close to blade root/tip.

## Purpose
Useful to decide what to optimize in the blade

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Tests are passing

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [x] I have added necessary documentation