### PR TITLE
coord_xy_dim not needed

### DIFF
--- a/wisdem/glue_code/glue_code.py
+++ b/wisdem/glue_code/glue_code.py
@@ -149,7 +149,6 @@ class WT_RNTA(om.Group):
             if opt_options["constraints"]["blade"]["rail_transport"]["flag"]:
                 self.connect("blade.outer_shape_bem.pitch_axis", "re.rail.pitch_axis")
                 self.connect("assembly.blade_ref_axis", "re.rail.blade_ref_axis")
-                self.connect("blade.interp_airfoils.coord_xy_dim", "re.rail.coord_xy_dim")
                 self.connect("blade.interp_airfoils.coord_xy_interp", "re.rail.coord_xy_interp")
 
             # Connections from blade struct parametrization to rotor load anlysis


### PR DESCRIPTION
Fix a little bug: coord_xy_dim is no longer used in the rail transport model

## Purpose
Bug fix

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
The examples don't currently run the rail transport model... and so we missed the bug in _glue_code.py_

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation