### PR TITLE
Set default verify level to -1 to avoid unnecessary FD check on SNOPT

### DIFF
--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+
 import openmdao.api as om
 
 
@@ -200,6 +201,8 @@ class PoseOptimization(object):
                     wt_opt.driver.hist_file = self.opt["driver"]["optimization"]["hist_file_name"]
                 if "verify_level" in self.opt["driver"]["optimization"]:
                     wt_opt.driver.opt_settings["Verify level"] = self.opt["driver"]["optimization"]["verify_level"]
+                else:
+                    wt_opt.driver.opt_settings["Verify level"] = -1
                 # wt_opt.driver.declare_coloring()
                 if "hotstart_file" in self.opt["driver"]["optimization"]:
                     wt_opt.driver.hotstart_file = self.opt["driver"]["optimization"]["hotstart_file"]


### PR DESCRIPTION
The default behavior of SNOPT is to check the derivatives using FD.
Since we're only FDing over WISDEM and WEIS (for now), this is irrelevant.
This PR sets the default behavior within WISDEM to skip this check, which saves computational time.