### PR TITLE
Rotorse group to simplify glue code

### DIFF
--- a/examples/14_overridden_values/driver.py
+++ b/examples/14_overridden_values/driver.py
@@ -19,7 +19,7 @@ fname_modeling_options = mydir + os.sep + "modeling_options.yaml"
 fname_analysis_options = mydir + os.sep + "analysis_options.yaml"
 
 wt_opt, modeling_options, analysis_options = run_wisdem(fname_wt_input, fname_modeling_options, fname_analysis_options)
-print(f"Tip deflection: {wt_opt['rs.tip_pos.tip_deflection'][0]} meters")
+print(f"Tip deflection: {wt_opt['rotorse.rs.tip_pos.tip_deflection'][0]} meters")
 
 
 # Construct a dict with values to overwrite
@@ -33,4 +33,4 @@ wt_opt, modeling_options, opt_options = run_wisdem(
     fname_analysis_options,
     overridden_values=overridden_values,
 )
-print(f"Tip deflection: {wt_opt['rs.tip_pos.tip_deflection'][0]} meters")
+print(f"Tip deflection: {wt_opt['rotorse.rs.tip_pos.tip_deflection'][0]} meters")

--- a/examples/14_overridden_values/driver.py
+++ b/examples/14_overridden_values/driver.py
@@ -24,7 +24,7 @@ print(f"Tip deflection: {wt_opt['rotorse.rs.tip_pos.tip_deflection'][0]} meters"
 
 # Construct a dict with values to overwrite
 overridden_values = {}
-overridden_values["wt_class.V_mean_overwrite"] = 11.5
+overridden_values["rotorse.wt_class.V_mean_overwrite"] = 11.5
 
 # Run the modified simulation with the overwritten values
 wt_opt, modeling_options, opt_options = run_wisdem(

--- a/wisdem/ccblade/ccblade_component.py
+++ b/wisdem/ccblade/ccblade_component.py
@@ -152,7 +152,7 @@ class CCBladeLoads(ExplicitComponent):
     hubloss : boolean
         Include Prandtl hub loss model.
     wakerotation : boolean
-        Iclude effect of wake rotation (i.e., tangential induction factor is nonzero).
+        Include effect of wake rotation (i.e., tangential induction factor is nonzero).
     usecd : boolean
         Use drag coefficient in computing induction factors.
 

--- a/wisdem/glue_code/gc_LoadInputs.py
+++ b/wisdem/glue_code/gc_LoadInputs.py
@@ -804,10 +804,10 @@ class WindTurbineOntologyPython(object):
             K = []
             for i in range(self.modeling_options["WISDEM"]["RotorSE"]["n_span"]):
                 Ki = np.zeros(21)
-                Ki[11] = wt_opt["re.EA"][i]
-                Ki[15] = wt_opt["re.EIxx"][i]
-                Ki[18] = wt_opt["re.EIyy"][i]
-                Ki[20] = wt_opt["re.GJ"][i]
+                Ki[11] = wt_opt["rotorse.EA"][i]
+                Ki[15] = wt_opt["rotorse.EIxx"][i]
+                Ki[18] = wt_opt["rotorse.EIyy"][i]
+                Ki[20] = wt_opt["rotorse.GJ"][i]
                 K.append(Ki.tolist())
             self.wt_init["components"]["blade"]["elastic_properties_mb"]["six_x_six"]["stiff_matrix"]["values"] = K
             self.wt_init["components"]["blade"]["elastic_properties_mb"]["six_x_six"]["inertia_matrix"] = {}
@@ -817,17 +817,17 @@ class WindTurbineOntologyPython(object):
             I = []
             for i in range(self.modeling_options["WISDEM"]["RotorSE"]["n_span"]):
                 Ii = np.zeros(21)
-                Ii[0] = wt_opt["re.rhoA"][i]
-                Ii[5] = -wt_opt["re.rhoA"][i] * wt_opt["re.y_cg"][i]
-                Ii[6] = wt_opt["re.rhoA"][i]
-                Ii[10] = wt_opt["re.rhoA"][i] * wt_opt["re.x_cg"][i]
-                Ii[11] = wt_opt["re.rhoA"][i]
-                Ii[12] = wt_opt["re.rhoA"][i] * wt_opt["re.y_cg"][i]
-                Ii[13] = -wt_opt["re.rhoA"][i] * wt_opt["re.x_cg"][i]
-                Ii[15] = wt_opt["re.precomp.edge_iner"][i]
-                Ii[16] = wt_opt["re.precomp.edge_iner"][i]
+                Ii[0] = wt_opt["rotorse.rhoA"][i]
+                Ii[5] = -wt_opt["rotorse.rhoA"][i] * wt_opt["rotorse.re.y_cg"][i]
+                Ii[6] = wt_opt["rotorse.rhoA"][i]
+                Ii[10] = wt_opt["rotorse.rhoA"][i] * wt_opt["rotorse.re.x_cg"][i]
+                Ii[11] = wt_opt["rotorse.rhoA"][i]
+                Ii[12] = wt_opt["rotorse.rhoA"][i] * wt_opt["rotorse.re.y_cg"][i]
+                Ii[13] = -wt_opt["rotorse.rhoA"][i] * wt_opt["rotorse.re.x_cg"][i]
+                Ii[15] = wt_opt["rotorse.re.precomp.edge_iner"][i]
+                Ii[16] = wt_opt["rotorse.re.precomp.edge_iner"][i]
                 # Ii[18] = wt_opt['re.precomp.edge_iner'][i]
-                Ii[20] = wt_opt["re.rhoJ"][i]
+                Ii[20] = wt_opt["rotorse.rhoJ"][i]
                 I.append(Ii.tolist())
             self.wt_init["components"]["blade"]["elastic_properties_mb"]["six_x_six"]["inertia_matrix"]["values"] = I
 

--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-
 import openmdao.api as om
 
 
@@ -397,10 +396,10 @@ class PoseOptimization(object):
 
         # Set merit figure. Each objective has its own scaling.
         if self.opt["merit_figure"] == "AEP":
-            wt_opt.model.add_objective("rp.AEP", ref=-1.0e6)
+            wt_opt.model.add_objective("rotorse.rp.AEP", ref=-1.0e6)
 
         elif self.opt["merit_figure"] == "blade_mass":
-            wt_opt.model.add_objective("re.precomp.blade_mass", ref=1.0e4)
+            wt_opt.model.add_objective("rotorse.re.precomp.blade_mass", ref=1.0e4)
 
         elif self.opt["merit_figure"] == "LCOE":
             wt_opt.model.add_objective("financese.lcoe", ref=0.1)
@@ -443,9 +442,9 @@ class PoseOptimization(object):
 
         elif self.opt["merit_figure"] == "Cp":
             if self.modeling["flags"]["blade"]:
-                wt_opt.model.add_objective("rp.powercurve.Cp_regII", ref=-1.0)
+                wt_opt.model.add_objective("rotorse.rp.powercurve.Cp_regII", ref=-1.0)
             else:
-                wt_opt.model.add_objective("ccblade.CP", ref=-1.0)
+                wt_opt.model.add_objective("rotorse.ccblade.CP", ref=-1.0)
         else:
             raise ValueError("The merit figure " + self.opt["merit_figure"] + " is unknown or not supported.")
 
@@ -815,7 +814,7 @@ class PoseOptimization(object):
                     blade_constr["strains_spar_cap_ss"]["index_start"], blade_constr["strains_spar_cap_ss"]["index_end"]
                 )
                 wt_opt.model.add_constraint(
-                    "rs.constr.constr_max_strainU_spar", indices=indices_strains_spar_cap_ss, upper=1.0
+                    "rotorse.rs.constr.constr_max_strainU_spar", indices=indices_strains_spar_cap_ss, upper=1.0
                 )
             else:
                 print(
@@ -835,7 +834,7 @@ class PoseOptimization(object):
                     blade_constr["strains_spar_cap_ps"]["index_start"], blade_constr["strains_spar_cap_ps"]["index_end"]
                 )
                 wt_opt.model.add_constraint(
-                    "rs.constr.constr_max_strainL_spar", indices=indices_strains_spar_cap_ps, upper=1.0
+                    "rotorse.rs.constr.constr_max_strainL_spar", indices=indices_strains_spar_cap_ps, upper=1.0
                 )
             else:
                 print(
@@ -844,7 +843,7 @@ class PoseOptimization(object):
 
         if blade_constr["stall"]["flag"]:
             if blade_opt["aero_shape"]["twist"]["flag"]:
-                wt_opt.model.add_constraint("stall_check.no_stall_constraint", upper=1.0)
+                wt_opt.model.add_constraint("rotorse.stall_check.no_stall_constraint", upper=1.0)
             else:
                 print(
                     "WARNING: the margin to stall is set to be constrained, but twist is not an active design variable. The constraint is not enforced."
@@ -868,7 +867,9 @@ class PoseOptimization(object):
 
         if blade_constr["root_circle_diameter"]["flag"]:
             if blade_opt["aero_shape"]["chord"]["flag"] and blade_opt["aero_shape"]["chord"]["index_start"] == 0.0:
-                wt_opt.model.add_constraint("rs.brs.ratio", upper=blade_constr["root_circle_diameter"]["max_ratio"])
+                wt_opt.model.add_constraint(
+                    "rotorse.rs.brs.ratio", upper=blade_constr["root_circle_diameter"]["max_ratio"]
+                )
             else:
                 print(
                     "WARNING: the blade root size is set to be constrained, but chord at blade root is not an active design variable. The constraint is not enforced."
@@ -876,27 +877,27 @@ class PoseOptimization(object):
 
         if blade_constr["frequency"]["flap_3P"]:
             if blade_opt["structure"]["spar_cap_ss"]["flag"] or blade_opt["structure"]["spar_cap_ps"]["flag"]:
-                wt_opt.model.add_constraint("rs.constr.constr_flap_f_margin", upper=0.0)
+                wt_opt.model.add_constraint("rotorse.rs.constr.constr_flap_f_margin", upper=0.0)
             else:
                 print(
                     "WARNING: the blade flap frequencies are set to be constrained, but spar caps thickness is not an active design variable. The constraint is not enforced."
                 )
 
         if blade_constr["frequency"]["edge_3P"]:
-            wt_opt.model.add_constraint("rs.constr.constr_edge_f_margin", upper=0.0)
+            wt_opt.model.add_constraint("rotorse.rs.constr.constr_edge_f_margin", upper=0.0)
 
         if blade_constr["rail_transport"]["8_axle"]:
-            wt_opt.model.add_constraint("re.rail.constr_LV_8axle_horiz", lower=0.8, upper=1.0)
-            wt_opt.model.add_constraint("re.rail.constr_strainPS", upper=1.0)
-            wt_opt.model.add_constraint("re.rail.constr_strainSS", upper=1.0)
+            wt_opt.model.add_constraint("rotorse.re.rail.constr_LV_8axle_horiz", lower=0.8, upper=1.0)
+            wt_opt.model.add_constraint("rotorse.re.rail.constr_strainPS", upper=1.0)
+            wt_opt.model.add_constraint("rotorse.re.rail.constr_strainSS", upper=1.0)
         elif blade_constr["rail_transport"]["4_axle"]:
-            wt_opt.model.add_constraint("re.rail.constr_LV_4axle_horiz", upper=1.0)
-            wt_opt.model.add_constraint("re.rail.constr_strainPS", upper=1.0)
-            wt_opt.model.add_constraint("re.rail.constr_strainSS", upper=1.0)
+            wt_opt.model.add_constraint("rotorse.re.rail.constr_LV_4axle_horiz", upper=1.0)
+            wt_opt.model.add_constraint("rotorse.re.rail.constr_strainPS", upper=1.0)
+            wt_opt.model.add_constraint("rotorse.re.rail.constr_strainSS", upper=1.0)
 
         if self.opt["constraints"]["blade"]["moment_coefficient"]["flag"]:
             wt_opt.model.add_constraint(
-                "ccblade.CM",
+                "rotorse.ccblade.CM",
                 lower=self.opt["constraints"]["blade"]["moment_coefficient"]["min"],
                 upper=self.opt["constraints"]["blade"]["moment_coefficient"]["max"],
             )
@@ -910,9 +911,13 @@ class PoseOptimization(object):
             target_cd = np.interp(eta_opt, data_target[:, 0], data_target[:, 4])
             eps_cl = 1.0e-2
             if self.opt["constraints"]["blade"]["match_cl_cd"]["flag_cl"]:
-                wt_opt.model.add_constraint("ccblade.cl_n_opt", lower=target_cl - eps_cl, upper=target_cl + eps_cl)
+                wt_opt.model.add_constraint(
+                    "rotorse.ccblade.cl_n_opt", lower=target_cl - eps_cl, upper=target_cl + eps_cl
+                )
             if self.opt["constraints"]["blade"]["match_cl_cd"]["flag_cd"]:
-                wt_opt.model.add_constraint("ccblade.cd_n_opt", lower=target_cd - eps_cl, upper=target_cd + eps_cl)
+                wt_opt.model.add_constraint(
+                    "rotorse.ccblade.cd_n_opt", lower=target_cd - eps_cl, upper=target_cd + eps_cl
+                )
         if (
             self.opt["constraints"]["blade"]["match_L_D"]["flag_L"]
             or self.opt["constraints"]["blade"]["match_L_D"]["flag_D"]
@@ -923,9 +928,9 @@ class PoseOptimization(object):
             target_D = np.interp(eta_opt, data_target[:, 0], data_target[:, 8])
         eps_L = 1.0e2
         if self.opt["constraints"]["blade"]["match_L_D"]["flag_L"]:
-            wt_opt.model.add_constraint("ccblade.L_n_opt", lower=target_L - eps_L, upper=target_L + eps_L)
+            wt_opt.model.add_constraint("rotorse.ccblade.L_n_opt", lower=target_L - eps_L, upper=target_L + eps_L)
         if self.opt["constraints"]["blade"]["match_L_D"]["flag_D"]:
-            wt_opt.model.add_constraint("ccblade.D_n_opt", lower=target_D - eps_L, upper=target_D + eps_L)
+            wt_opt.model.add_constraint("rotorse.ccblade.D_n_opt", lower=target_D - eps_L, upper=target_D + eps_L)
 
         # Tower and monopile contraints
         tower_constr = self.opt["constraints"]["tower"]
@@ -1118,9 +1123,9 @@ class PoseOptimization(object):
                 wt_opt["blade.opt_var.spar_cap_ss_opt"] = init_spar_cap_ss_opt
                 wt_opt["blade.opt_var.spar_cap_ps_opt"] = init_spar_cap_ps_opt
             blade_constr = self.opt["constraints"]["blade"]
-            wt_opt["rs.constr.max_strainU_spar"] = blade_constr["strains_spar_cap_ss"]["max"]
-            wt_opt["rs.constr.max_strainL_spar"] = blade_constr["strains_spar_cap_ps"]["max"]
-            wt_opt["stall_check.stall_margin"] = blade_constr["stall"]["margin"] * 180.0 / np.pi
+            wt_opt["rotorse.rs.constr.max_strainU_spar"] = blade_constr["strains_spar_cap_ss"]["max"]
+            wt_opt["rotorse.rs.constr.max_strainL_spar"] = blade_constr["strains_spar_cap_ps"]["max"]
+            wt_opt["rotorse.stall_check.stall_margin"] = blade_constr["stall"]["margin"] * 180.0 / np.pi
             wt_opt["tcons.max_allowable_td_ratio"] = blade_constr["tip_deflection"]["margin"]
 
         if self.modeling["flags"]["nacelle"] and self.modeling["WISDEM"]["DriveSE"]["direct"]:

--- a/wisdem/inputs/modeling_schema.yaml
+++ b/wisdem/inputs/modeling_schema.yaml
@@ -126,6 +126,28 @@ properties:
                         minimum: 0.1
                         maximum: 1.e+2
                         description: Safety factor for the max stress of blade root fasteners
+                    hubloss:
+                        type: boolean
+                        default: True
+                        description: Include Prandtl hub loss model in CCBlade calls
+                    tiploss:
+                        type: boolean
+                        default: True
+                        description: Include Prandtl tip loss model in CCBlade calls
+                    wakerotation:
+                        type: boolean
+                        default: True
+                        description: Include effect of wake rotation (i.e., tangential induction factor is nonzero) in CCBlade calls
+                    usecd:
+                        type: boolean
+                        default: True
+                        description: Use drag coefficient in computing induction factors in CCBlade calls
+                    n_sector:
+                        type: integer
+                        default: 4
+                        minimum: 1
+                        maximum: 10
+                        description: Number of sectors to divide rotor face into in computing thrust and power.
             DriveSE:
                 type: object
                 default: {}

--- a/wisdem/postprocessing/compare_designs.py
+++ b/wisdem/postprocessing/compare_designs.py
@@ -281,14 +281,14 @@ def create_all_plots(
         faoa, axaoa = plt.subplots(1, 1, figsize=(5.3, 4))
         for idx, (yaml_data, label) in enumerate(zip(list_of_sims, list_of_labels)):
             axaoa.plot(
-                yaml_data["rotorse.stall_check.s"],
+                yaml_data["rotorse.s"],
                 yaml_data["rotorse.stall_check.aoa_along_span"],
                 "-",
                 color=colors[idx],
                 label=label,
             )
         axaoa.plot(
-            yaml_data["rotorse.stall_check.s"],
+            yaml_data["rotorse.s"],
             yaml_data["rotorse.stall_check.stall_angle_along_span"],
             ":",
             color=colors[idx + 1],

--- a/wisdem/postprocessing/compare_designs.py
+++ b/wisdem/postprocessing/compare_designs.py
@@ -250,14 +250,14 @@ def create_all_plots(
         for idx, (yaml_data, label) in enumerate(zip(list_of_sims, list_of_labels)):
             axeps.plot(
                 yaml_data["blade.outer_shape_bem.s"],
-                yaml_data["rs.frame.strainU_spar"] * 1.0e6,
+                yaml_data["rotorse.rs.frame.strainU_spar"] * 1.0e6,
                 "-",
                 color=colors[idx],
                 label=label,
             )
             axeps.plot(
                 yaml_data["blade.outer_shape_bem.s"],
-                yaml_data["rs.frame.strainL_spar"] * 1.0e6,
+                yaml_data["rotorse.rs.frame.strainL_spar"] * 1.0e6,
                 "-",
                 color=colors[idx],
             )
@@ -281,15 +281,15 @@ def create_all_plots(
         faoa, axaoa = plt.subplots(1, 1, figsize=(5.3, 4))
         for idx, (yaml_data, label) in enumerate(zip(list_of_sims, list_of_labels)):
             axaoa.plot(
-                yaml_data["stall_check.s"],
-                yaml_data["stall_check.aoa_along_span"],
+                yaml_data["rotorse.stall_check.s"],
+                yaml_data["rotorse.stall_check.aoa_along_span"],
                 "-",
                 color=colors[idx],
                 label=label,
             )
         axaoa.plot(
-            yaml_data["stall_check.s"],
-            yaml_data["stall_check.stall_angle_along_span"],
+            yaml_data["rotorse.stall_check.s"],
+            yaml_data["rotorse.stall_check.stall_angle_along_span"],
             ":",
             color=colors[idx + 1],
             label="Stall",
@@ -314,7 +314,7 @@ def create_all_plots(
         for idx, (yaml_data, label) in enumerate(zip(list_of_sims, list_of_labels)):
             axeff.plot(
                 yaml_data["blade.outer_shape_bem.s"],
-                yaml_data["rp.powercurve.cl_regII"] / yaml_data["rp.powercurve.cd_regII"],
+                yaml_data["rotorse.rp.powercurve.cl_regII"] / yaml_data["rotorse.rp.powercurve.cd_regII"],
                 "-",
                 color=colors[idx],
                 label=label,
@@ -465,7 +465,7 @@ def create_all_plots(
             "Blade Nondimensional Span [-]",
             "Edgewise Stiffness [Nm2]",
             "blade.outer_shape_bem.s",
-            "re.EIxx",
+            "rotorse.EIxx",
             "edge",
         )
 
@@ -474,7 +474,7 @@ def create_all_plots(
             "Blade Nondimensional Span [-]",
             "Torsional Stiffness [Nm2]",
             "blade.outer_shape_bem.s",
-            "re.GJ",
+            "rotorse.GJ",
             "torsion",
         )
 
@@ -483,7 +483,7 @@ def create_all_plots(
             "Blade Nondimensional Span [-]",
             "Flapwise Stiffness [Nm2]",
             "blade.outer_shape_bem.s",
-            "re.EIyy",
+            "rotorse.EIyy",
             "flap",
         )
 
@@ -492,7 +492,7 @@ def create_all_plots(
             "Blade Nondimensional Span [-]",
             "Unit Mass [kg/m]",
             "blade.outer_shape_bem.s",
-            "re.rhoA",
+            "rotorse.rhoA",
             "mass",
         )
     except KeyError:
@@ -516,7 +516,7 @@ def create_all_plots(
             "Blade Nondimensional Span [-]",
             "Axial Induction [-]",
             "blade.outer_shape_bem.s",
-            "rp.powercurve.ax_induct_regII",
+            "rotorse.rp.powercurve.ax_induct_regII",
             "induction",
         )
 
@@ -525,7 +525,7 @@ def create_all_plots(
             "Blade Nondimensional Span [-]",
             "Lift Coefficient [-]",
             "blade.outer_shape_bem.s",
-            "rp.powercurve.cl_regII",
+            "rotorse.rp.powercurve.cl_regII",
             "lift_coeff",
         )
 
@@ -534,7 +534,7 @@ def create_all_plots(
             "Blade Nondimensional Span [-]",
             "Drag Coefficient [-]",
             "blade.outer_shape_bem.s",
-            "rp.powercurve.cd_regII",
+            "rotorse.rp.powercurve.cd_regII",
             "drag_coeff",
         )
 
@@ -542,8 +542,8 @@ def create_all_plots(
         simple_plot_results(
             "Wind velocity [m/s]",
             "Pitch angle [deg]",
-            "rp.powercurve.V",
-            "rp.powercurve.pitch",
+            "rotorse.rp.powercurve.V",
+            "rotorse.rp.powercurve.pitch",
             "pitch",
         )
 
@@ -551,8 +551,8 @@ def create_all_plots(
         simple_plot_results(
             "Wind velocity [m/s]",
             "Electrical Power [W]",
-            "rp.powercurve.V",
-            "rp.powercurve.P",
+            "rotorse.rp.powercurve.V",
+            "rotorse.rp.powercurve.P",
             "power_elec",
         )
 
@@ -560,8 +560,8 @@ def create_all_plots(
         simple_plot_results(
             "Wind velocity [m/s]",
             "Mechanical Power [W]",
-            "rp.powercurve.V",
-            "rp.powercurve.P_aero",
+            "rotorse.rp.powercurve.V",
+            "rotorse.rp.powercurve.P_aero",
             "power_aero",
         )
 
@@ -569,8 +569,8 @@ def create_all_plots(
         simple_plot_results(
             "Wind velocity [m/s]",
             "Electrical Power Coefficient [-]",
-            "rp.powercurve.V",
-            "rp.powercurve.Cp",
+            "rotorse.rp.powercurve.V",
+            "rotorse.rp.powercurve.Cp",
             "cp_elec",
         )
 
@@ -578,8 +578,8 @@ def create_all_plots(
         simple_plot_results(
             "Wind velocity [m/s]",
             "Mechanical Power Coefficient [-]",
-            "rp.powercurve.V",
-            "rp.powercurve.Cp_aero",
+            "rotorse.rp.powercurve.V",
+            "rotorse.rp.powercurve.Cp_aero",
             "cp_aero",
         )
 
@@ -587,8 +587,8 @@ def create_all_plots(
         simple_plot_results(
             "Wind velocity [m/s]",
             "Rotor speed [rpm]",
-            "rp.powercurve.V",
-            "rp.powercurve.Omega",
+            "rotorse.rp.powercurve.V",
+            "rotorse.rp.powercurve.Omega",
             "omega",
         )
 
@@ -596,8 +596,8 @@ def create_all_plots(
         simple_plot_results(
             "Wind velocity [m/s]",
             "Thrust [N]",
-            "rp.powercurve.V",
-            "rp.powercurve.T",
+            "rotorse.rp.powercurve.V",
+            "rotorse.rp.powercurve.T",
             "thrust",
         )
 
@@ -605,8 +605,8 @@ def create_all_plots(
         simple_plot_results(
             "Wind velocity [m/s]",
             "Thrust Coefficient [-]",
-            "rp.powercurve.V",
-            "rp.powercurve.Ct_aero",
+            "rotorse.rp.powercurve.V",
+            "rotorse.rp.powercurve.Ct_aero",
             "ct_aero",
         )
 
@@ -614,8 +614,8 @@ def create_all_plots(
         simple_plot_results(
             "Wind velocity [m/s]",
             "Torque [Nm]",
-            "rp.powercurve.V",
-            "rp.powercurve.Q",
+            "rotorse.rp.powercurve.V",
+            "rotorse.rp.powercurve.Q",
             "torque",
         )
 
@@ -623,8 +623,8 @@ def create_all_plots(
         simple_plot_results(
             "Wind velocity [m/s]",
             "Torque Coefficient [-]",
-            "rp.powercurve.V",
-            "rp.powercurve.Cq_aero",
+            "rotorse.rp.powercurve.V",
+            "rotorse.rp.powercurve.Cq_aero",
             "cq_aero",
         )
 
@@ -632,8 +632,8 @@ def create_all_plots(
         simple_plot_results(
             "Wind velocity [m/s]",
             "Blade moment [Nm]",
-            "rp.powercurve.V",
-            "rp.powercurve.M",
+            "rotorse.rp.powercurve.V",
+            "rotorse.rp.powercurve.M",
             "moment",
         )
 
@@ -641,8 +641,8 @@ def create_all_plots(
         simple_plot_results(
             "Wind velocity [m/s]",
             "Blade moment coefficient [-]",
-            "rp.powercurve.V",
-            "rp.powercurve.Cm_aero",
+            "rotorse.rp.powercurve.V",
+            "rotorse.rp.powercurve.Cm_aero",
             "cm_aero",
         )
     except KeyError:
@@ -740,24 +740,24 @@ def run(list_of_sims, list_of_labels, modeling_options, analysis_options):
     values_to_print = {
         "Rotor Diameter": ["assembly.rotor_diameter", "m"],
         "TSR": ["control.rated_TSR", None],
-        "AEP": ["rp.AEP", "GW*h"],
+        "AEP": ["rotorse.rp.AEP", "GW*h"],
         "LCOE": ["financese.lcoe", "USD/(MW*h)"],
-        # "Cp": ["rp.powercurve.Cp_aero", None],
-        "Rated velocity": ["rp.powercurve.rated_V", "m/s"],
-        "Rated rpm": ["rp.powercurve.rated_Omega", "rpm"],
+        # "Cp": ["rotorse.rp.powercurve.Cp_aero", None],
+        "Rated velocity": ["rotorse.rp.powercurve.rated_V", "m/s"],
+        "Rated rpm": ["rotorse.rp.powercurve.rated_Omega", "rpm"],
         "Rated pitch": ["control.rated_pitch", "deg"],
-        "Rated thrust": ["rp.powercurve.rated_T", "kN"],
-        "Rated torque": ["rp.powercurve.rated_Q", "kN*m"],
-        "Blade mass": ["re.precomp.blade_mass", "kg"],
-        "Blade cost": ["re.precomp.total_blade_cost", "USD"],
+        "Rated thrust": ["rotorse.rp.powercurve.rated_T", "kN"],
+        "Rated torque": ["rotorse.rp.powercurve.rated_Q", "kN*m"],
+        "Blade mass": ["rotorse.re.precomp.blade_mass", "kg"],
+        "Blade cost": ["rotorse.re.precomp.total_blade_cost", "USD"],
         "Tip defl": ["tcons.tip_deflection", "m"],
         "Tip defl ratio": ["tcons.tip_deflection_ratio", None],
-        "Flap freqs": ["rs.frame.flap_mode_freqs", "Hz"],
-        "Edge freqs": ["rs.frame.edge_mode_freqs", "Hz"],
-        "3P freq": ["rp.powercurve.rated_Omega", None, 3.0 / 60],
-        "6P freq": ["rp.powercurve.rated_Omega", None, 6.0 / 60],
-        "Hub forces": ["rs.aero_hub_loads.Fxyz_hub_aero", "kN"],
-        "Hub moments": ["rs.aero_hub_loads.Mxyz_hub_aero", "kN*m"],
+        "Flap freqs": ["rotorse.rs.frame.flap_mode_freqs", "Hz"],
+        "Edge freqs": ["rotorse.rs.frame.edge_mode_freqs", "Hz"],
+        "3P freq": ["rotorse.rp.powercurve.rated_Omega", None, 3.0 / 60],
+        "6P freq": ["rotorse.rp.powercurve.rated_Omega", None, 6.0 / 60],
+        "Hub forces": ["rotorse.rs.aero_hub_loads.Fxyz_hub_aero", "kN"],
+        "Hub moments": ["rotorse.rs.aero_hub_loads.Mxyz_hub_aero", "kN*m"],
         "Nacelle mass": ["drivese.nacelle_mass", "kg"],
         "RNA mass": ["drivese.rna_mass", "kg"],
         "Tower mass": ["towerse.tower_mass", "kg"],

--- a/wisdem/rotorse/rotor.py
+++ b/wisdem/rotorse/rotor.py
@@ -1,0 +1,114 @@
+import openmdao.api as om
+from wisdem.rotorse.rotor_power import RotorPower, NoStallConstraint
+from wisdem.commonse.turbine_class import TurbineClass
+from wisdem.rotorse.rotor_structure import RotorStructure
+from wisdem.rotorse.rotor_elasticity import RotorElasticity
+from wisdem.ccblade.ccblade_component import CCBladeTwist
+
+
+class RotorSE(om.Group):
+    def initialize(self):
+        self.options.declare("modeling_options")
+        self.options.declare("opt_options")
+
+    def setup(self):
+        modeling_options = self.options["modeling_options"]
+        opt_options = self.options["opt_options"]
+
+        promoteGeom = [
+            "A",
+            "EA",
+            "EIxx",
+            "EIyy",
+            "EIxy",
+            "GJ",
+            "rhoA",
+            "rhoJ",
+            "x_ec",
+            "y_ec",
+            "xu_strain_spar",
+            "xl_strain_spar",
+            "yu_strain_spar",
+            "yl_strain_spar",
+            "xu_strain_te",
+            "xl_strain_te",
+            "yu_strain_te",
+            "yl_strain_te",
+        ]
+
+        promoteCC = [
+            "chord",
+            "theta",
+            "r",
+            "Rtip",
+            "Rhub",
+            "hub_height",
+            "precone",
+            "tilt",
+            "precurve",
+            "presweep",
+            "airfoils_aoa",
+            "airfoils_Re",
+            "airfoils_cl",
+            "airfoils_cd",
+            "airfoils_cm",
+            "nBlades",
+            ("rho", "rho_air"),
+            ("mu", "mu_air"),
+            "shearExp",
+            "hubloss",
+            "tiploss",
+            "wakerotation",
+            "usecd",
+            "nSector",
+            "yaw",
+        ]
+
+        self.add_subsystem(
+            "ccblade",
+            CCBladeTwist(modeling_options=modeling_options, opt_options=opt_options),
+            promotes=promoteCC + ["pitch", "tsr", "precurveTip", "presweepTip"],
+        )  # Run standalone CCBlade and possibly determine optimal twist from user-defined margin to stall
+
+        self.add_subsystem("wt_class", TurbineClass())
+
+        self.add_subsystem(
+            "re",
+            RotorElasticity(modeling_options=modeling_options, opt_options=opt_options),
+            promotes=promoteGeom + ["chord", "theta", "r", "precurve", "presweep"],
+        )
+
+        self.add_subsystem(
+            "rp",
+            RotorPower(modeling_options=modeling_options),
+            promotes=promoteCC + ["precurveTip", "presweepTip", ("tsr_operational", "tsr"), ("control_pitch", "pitch")],
+        )
+
+        self.add_subsystem(
+            "stall_check",
+            NoStallConstraint(modeling_options=modeling_options),
+            promotes=["s", "airfoils_aoa", "airfoils_cl", "airfoils_cd", "airfoils_cm"],
+        )
+
+        self.add_subsystem(
+            "rs",
+            RotorStructure(modeling_options=modeling_options, opt_options=opt_options, freq_run=False),
+            promotes=promoteGeom + promoteCC + ["s", "precurveTip"],
+        )
+
+        # Connection from ra to rs for the rated conditions
+        self.connect("rp.gust.V_gust", ["rs.aero_gust.V_load", "rs.aero_hub_loads.V_load"])
+        self.connect(
+            "rp.powercurve.rated_Omega", ["rs.Omega_load", "rs.tot_loads_gust.aeroloads_Omega", "rs.constr.rated_Omega"]
+        )
+        self.connect("rp.powercurve.rated_pitch", ["rs.pitch_load", "rs.tot_loads_gust.aeroloads_pitch"])
+
+        # Connections to RotorPower
+        self.connect("wt_class.V_mean", "rp.cdf.xbar")
+        self.connect("wt_class.V_mean", "rp.gust.V_mean")
+
+        # Connections to the stall check
+        if modeling_options["flags"]["blade"]:
+            self.connect("rp.powercurve.aoa_regII", "stall_check.aoa_along_span")
+        else:
+            self.connect("ccblade.alpha", "stall_check.aoa_along_span")

--- a/wisdem/rotorse/rotor.py
+++ b/wisdem/rotorse/rotor.py
@@ -64,6 +64,14 @@ class RotorSE(om.Group):
             "yaw",
         ]
 
+        ivc = om.IndepVarComp()
+        ivc.add_discrete_output("hubloss", val=modeling_options["WISDEM"]["RotorSE"]["hubloss"])
+        ivc.add_discrete_output("tiploss", val=modeling_options["WISDEM"]["RotorSE"]["tiploss"])
+        ivc.add_discrete_output("wakerotation", val=modeling_options["WISDEM"]["RotorSE"]["wakerotation"])
+        ivc.add_discrete_output("usecd", val=modeling_options["WISDEM"]["RotorSE"]["usecd"])
+        ivc.add_discrete_output("nSector", val=modeling_options["WISDEM"]["RotorSE"]["n_sector"])
+        self.add_subsystem("ivc", ivc, promotes=["*"])
+
         self.add_subsystem(
             "ccblade",
             CCBladeTwist(modeling_options=modeling_options, opt_options=opt_options),

--- a/wisdem/rotorse/rotor_elasticity.py
+++ b/wisdem/rotorse/rotor_elasticity.py
@@ -990,7 +990,22 @@ class RotorElasticity(Group):
         opt_options = self.options["opt_options"]
 
         # Get elastic properties by running precomp
-        promote_list = ["chord", "theta", "A", "EA", "EIxx", "EIyy", "EIxy", "GJ", "rhoA", "rhoJ", "x_sc", "y_sc"]
+        promote_list = [
+            "chord",
+            "theta",
+            "A",
+            "EA",
+            "EIxx",
+            "EIyy",
+            "EIxy",
+            "GJ",
+            "rhoA",
+            "rhoJ",
+            "x_sc",
+            "y_sc",
+            "pitch_axis",
+            "coord_xy_interp",
+        ]
         self.add_subsystem(
             "precomp",
             RunPreComp(modeling_options=modeling_options, opt_options=opt_options),
@@ -1010,6 +1025,14 @@ class RotorElasticity(Group):
                 "sc_ps_mats",
                 "te_ss_mats",
                 "te_ps_mats",
+                "xu_strain_spar",
+                "xl_strain_spar",
+                "yu_strain_spar",
+                "yl_strain_spar",
+                "xu_strain_te",
+                "xl_strain_te",
+                "yu_strain_te",
+                "yl_strain_te",
             ],
         )
         # Check rail transportabiliy

--- a/wisdem/rotorse/rotor_power.py
+++ b/wisdem/rotorse/rotor_power.py
@@ -59,6 +59,12 @@ class RotorPower(Group):
                 "nBlades",
                 "rho",
                 "mu",
+                "shearExp",
+                "hubloss",
+                "tiploss",
+                "wakerotation",
+                "usecd",
+                "nSector",
             ],
         )
         self.add_subsystem("gust", GustETM(std=modeling_options["WISDEM"]["RotorSE"]["gust_std"]))

--- a/wisdem/test/test_gluecode/test_gc_modified_yaml.py
+++ b/wisdem/test/test_gluecode/test_gc_modified_yaml.py
@@ -29,10 +29,10 @@ class TestRegression(unittest.TestCase):
             fname_wt_input, fname_modeling_options, fname_analysis_options
         )
 
-        self.assertAlmostEqual(wt_opt["re.precomp.blade_mass"][0], 69911.6542917299, 1)
-        self.assertAlmostEqual(wt_opt["rp.AEP"][0] * 1.0e-6, 77.84277082383369, 1)
-        self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 64.1372990450, 1)
-        self.assertAlmostEqual(wt_opt["rs.tip_pos.tip_deflection"][0], 25.4598632918, 1)
+        self.assertAlmostEqual(wt_opt["rotorse.re.precomp.blade_mass"][0], 69911.6542917299, 1)
+        self.assertAlmostEqual(wt_opt["rotorse.rp.AEP"][0] * 1.0e-6, 77.84277082383369, 1)
+        self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 64.1511606896, 1)
+        self.assertAlmostEqual(wt_opt["rotorse.rs.tip_pos.tip_deflection"][0], 25.3128523021, 1)
         self.assertAlmostEqual(wt_opt["towerse.z_param"][-1], 144.386, 3)
 
 

--- a/wisdem/test/test_gluecode/test_gluecode.py
+++ b/wisdem/test/test_gluecode/test_gluecode.py
@@ -25,10 +25,10 @@ class TestRegression(unittest.TestCase):
             fname_wt_input, fname_modeling_options, fname_analysis_options
         )
 
-        self.assertAlmostEqual(wt_opt["re.precomp.blade_mass"][0], 16403.682326940743, 2)
-        self.assertAlmostEqual(wt_opt["rp.AEP"][0] * 1.0e-6, 23.8821935913, 2)
+        self.assertAlmostEqual(wt_opt["rotorse.re.precomp.blade_mass"][0], 16403.682326940743, 2)
+        self.assertAlmostEqual(wt_opt["rotorse.rp.AEP"][0] * 1.0e-6, 23.8821935913, 2)
         self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 51.6575941808, 2)
-        self.assertAlmostEqual(wt_opt["rs.tip_pos.tip_deflection"][0], 4.4814362481, 1)
+        self.assertAlmostEqual(wt_opt["rotorse.rs.tip_pos.tip_deflection"][0], 4.4814362481, 1)
         self.assertAlmostEqual(wt_opt["towerse.z_param"][-1], 87.7, 2)
 
     def test15MW(self):
@@ -38,10 +38,10 @@ class TestRegression(unittest.TestCase):
             fname_wt_input, fname_modeling_options, fname_analysis_options
         )
 
-        self.assertAlmostEqual(wt_opt["re.precomp.blade_mass"][0], 69911.6542917299, 1)
-        self.assertAlmostEqual(wt_opt["rp.AEP"][0] * 1.0e-6, 77.76990259134561, 1)
+        self.assertAlmostEqual(wt_opt["rotorse.re.precomp.blade_mass"][0], 69911.6542917299, 1)
+        self.assertAlmostEqual(wt_opt["rotorse.rp.AEP"][0] * 1.0e-6, 77.76990259134561, 1)
         self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 64.1977089928, 1)
-        self.assertAlmostEqual(wt_opt["rs.tip_pos.tip_deflection"][0], 25.4598658124, 1)
+        self.assertAlmostEqual(wt_opt["rotorse.rs.tip_pos.tip_deflection"][0], 25.312853876, 1)
         self.assertAlmostEqual(wt_opt["towerse.z_param"][-1], 144.386, 3)
 
     def test3p4MW(self):
@@ -51,10 +51,10 @@ class TestRegression(unittest.TestCase):
             fname_wt_input, fname_modeling_options, fname_analysis_options
         )
 
-        self.assertAlmostEqual(wt_opt["re.precomp.blade_mass"][0], 14555.7435212969, 1)
-        self.assertAlmostEqual(wt_opt["rp.AEP"][0] * 1.0e-6, 13.6037235499, 1)
+        self.assertAlmostEqual(wt_opt["rotorse.re.precomp.blade_mass"][0], 14555.7435212969, 1)
+        self.assertAlmostEqual(wt_opt["rotorse.rp.AEP"][0] * 1.0e-6, 13.6037235499, 1)
         self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 37.4970510481, 1)
-        self.assertAlmostEqual(wt_opt["rs.tip_pos.tip_deflection"][0], 6.9771055306, 1)
+        self.assertAlmostEqual(wt_opt["rotorse.rs.tip_pos.tip_deflection"][0], 7.0474157383, 1)
         self.assertAlmostEqual(wt_opt["towerse.z_param"][-1], 108.0, 3)
 
 

--- a/wisdem/test/test_rotorse/test_rotor_structure.py
+++ b/wisdem/test/test_rotorse/test_rotor_structure.py
@@ -153,10 +153,7 @@ class TestRS(unittest.TestCase):
 
     def testRunFrame3DD(self):
         inputs = {}
-        outputs0 = {}
         outputs = {}
-        discrete_inputs = {}
-        discrete_outputs = {}
 
         nrel5mw = np.load(ARCHIVE)
         for k in nrel5mw.files:
@@ -164,8 +161,6 @@ class TestRS(unittest.TestCase):
 
         npts = len(inputs["r"])
         nfreq = 10
-        myzero = np.zeros(npts)
-        myone = np.ones(npts)
         options = {}
         options["WISDEM"] = {}
         options["WISDEM"]["RotorSE"] = {}


### PR DESCRIPTION
## Purpose
All WISDEM modules have a top-level group that is imported into the glue code except for the Rotor.  There used to be a RotorSE group before the IEAontology4all branch and now things are stable enough to bring it back.  Using some promoted variable names in the RotorSE group also simplifies the glue code quite a bit.  I was also able to catch a few missing connections.

**The downside is that post-processing scripts that access rotor outputs will need to change to add the `rotorse` prefix.** For instance, `rotorse.re.precomp.blade_mass`.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation