### PR TITLE
fix rad/deg bug in computation of cone along blade

### DIFF
--- a/wisdem/ccblade/ccblade_component.py
+++ b/wisdem/ccblade/ccblade_component.py
@@ -924,10 +924,10 @@ class AeroHubLoads(ExplicitComponent):
         dx_dx = np.eye(3 * n)
 
         x_az, x_azd, y_az, y_azd, z_az, z_azd, cone, coned, s, sd = _bem.definecurvature_dv2(
-            r, dx_dx[:, :n], precurve, dx_dx[:, n : 2 * n], presweep, dx_dx[:, 2 * n :], precone, np.zeros(3 * n)
+            r, dx_dx[:, :n], precurve, dx_dx[:, n : 2 * n], presweep, dx_dx[:, 2 * n :], float(np.deg2rad(precone)), np.zeros(3 * n)
         )
 
-        totalCone = precone + np.degrees(cone)
+        totalCone = np.degrees(cone)
         s = r[0] + s
 
         af = [None] * self.n_span


### PR DESCRIPTION
While working on the hub forces/moments for Matt I found a bug in the computation of the local cone angle along the blade span. The cone was not passed in rad but in degrees, and it was summed twice. @gbarter, please take a look!

## Purpose
Bug fix while working for WEIS Level 1

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation