### PR TITLE
ability to overwrite the IEC mean U for aep calcs

### DIFF
--- a/wisdem/glue_code/gc_WT_InitModel.py
+++ b/wisdem/glue_code/gc_WT_InitModel.py
@@ -1133,6 +1133,7 @@ def assign_environment_values(wt_opt, environment, offshore):
     wt_opt["env.shear_exp"] = environment["shear_exp"]
     wt_opt["env.G_soil"] = environment["soil_shear_modulus"]
     wt_opt["env.nu_soil"] = environment["soil_poisson"]
+    wt_opt['rotorse.wt_class.V_mean_overwrite'] = environment['V_mean']
 
     return wt_opt
 

--- a/wisdem/glue_code/gc_WT_InitModel.py
+++ b/wisdem/glue_code/gc_WT_InitModel.py
@@ -21,7 +21,8 @@ def yaml2openmdao(wt_opt, modeling_options, wt_init, opt_options):
     # Now all of the optional components
     if modeling_options["flags"]["environment"]:
         environment = wt_init["environment"]
-        wt_opt = assign_environment_values(wt_opt, environment, offshore)
+        blade_flag = modeling_options["flags"]["blade"]
+        wt_opt = assign_environment_values(wt_opt, environment, offshore, blade_flag)
     else:
         environment = {}
 
@@ -1118,7 +1119,7 @@ def assign_configuration_values(wt_opt, assembly, opt_options):
     return wt_opt
 
 
-def assign_environment_values(wt_opt, environment, offshore):
+def assign_environment_values(wt_opt, environment, offshore, blade_flag):
 
     wt_opt["env.rho_air"] = environment["air_density"]
     wt_opt["env.mu_air"] = environment["air_dyn_viscosity"]
@@ -1133,7 +1134,8 @@ def assign_environment_values(wt_opt, environment, offshore):
     wt_opt["env.shear_exp"] = environment["shear_exp"]
     wt_opt["env.G_soil"] = environment["soil_shear_modulus"]
     wt_opt["env.nu_soil"] = environment["soil_poisson"]
-    wt_opt['rotorse.wt_class.V_mean_overwrite'] = environment['V_mean']
+    if blade_flag:
+        wt_opt['rotorse.wt_class.V_mean_overwrite'] = environment['V_mean']
 
     return wt_opt
 

--- a/wisdem/inputs/geometry_schema.yaml
+++ b/wisdem/inputs/geometry_schema.yaml
@@ -3004,6 +3004,12 @@ properties:
                 minimum: 0
                 maximum: 0.6
                 default: 0.4
+            V_mean:
+                type: number
+                default: 0.
+                minimum: 0.
+                maximum: 2.e+1
+                description: Average inflow wind speed. If different than 0, this will overwrite the V mean of the IEC wind class
     bos:
         type: object
         default: {}


### PR DESCRIPTION
Add ability to overwrite the IEC mean wind speed based on WT wind class, see https://github.com/WISDEM/WISDEM/issues/284

## Purpose
Be able to control the average inflow wind speed

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I haven't added any specific example

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation