### PR TITLE
Avoid reducing nSector on the user

### DIFF
--- a/wisdem/ccblade/ccblade.py
+++ b/wisdem/ccblade/ccblade.py
@@ -601,7 +601,7 @@ class CCBlade(object):
 
         # azimuthal discretization
         if self.tilt == 0.0 and self.yaw == 0.0 and self.shearExp == 0.0:
-            self.nSector = 1  # no more are necessary
+            self.nSector = max(1, nSector)  # only 1 is necessary unless tilt, yaw, or shearExp get changed
         else:
             self.nSector = max(4, nSector)  # at least 4 are necessary
 


### PR DESCRIPTION
## Purpose
- Currently, when there is no yaw, tilt, or shear, ccBlade sets nSector=1 regardless of what the user specified. 
- This edit avoids that, to support cases where the user manually adds yaw, tilt, or shear after ccBlade has been initialized.

## Type of change
- Tiny tweak to enable additional flexibility

## Testing
Existing tests of CCBlade should be unaffected. This edit could be tested by comparing cases where shaft tilt is specified at initialization vs shaft tilt is manually added after initializing CCBlade with zero tilt.

## Checklist
- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation