### PR TITLE
b/normalization

### DIFF
--- a/wisdem/commonse/utilities.py
+++ b/wisdem/commonse/utilities.py
@@ -30,7 +30,7 @@ def get_modal_coefficients(x, y, deg=[2, 3, 4, 5, 6]):
         # p6 = np.zeros((5, y.shape[1]))
         # for k in range(y.shape[1]):
         #    p6[:, k], _ = curve_fit(mode_fit, xn, y[:, k])
-        normval = np.maximum(p6.sum(axis=0), 1e-6)
+        normval = np.maximum(np.abs(p6).sum(axis=0), 1e-6)
         p6 /= normval[np.newaxis, :]
     else:
         p6 = p6[2:]

--- a/wisdem/commonse/utilities.py
+++ b/wisdem/commonse/utilities.py
@@ -32,6 +32,7 @@ def get_modal_coefficients(x, y, deg=[2, 3, 4, 5, 6]):
         #    p6[:, k], _ = curve_fit(mode_fit, xn, y[:, k])
         normval = np.maximum(np.abs(p6).sum(axis=0), 1e-6)
         p6 /= normval[np.newaxis, :]
+        p6 /= np.sum(p6, axis=0)
     else:
         p6 = p6[2:]
         # p6, _ = curve_fit(mode_fit, xn, y)

--- a/wisdem/commonse/utilities.py
+++ b/wisdem/commonse/utilities.py
@@ -30,7 +30,7 @@ def get_modal_coefficients(x, y, deg=[2, 3, 4, 5, 6]):
         # p6 = np.zeros((5, y.shape[1]))
         # for k in range(y.shape[1]):
         #    p6[:, k], _ = curve_fit(mode_fit, xn, y[:, k])
-        normval = np.maximum(np.abs(p6).sum(axis=0), 1e-6)
+        normval = np.maximum(np.linalg.norm(p6, axis=0), 1e-6)
         p6 /= normval[np.newaxis, :]
         p6 /= np.sum(p6, axis=0)
     else:


### PR DESCRIPTION
## Purpose
This updates the normalization methods for the mode shape calculations. This is to make sure that, when the mode shapes are passed to ElastoDyn in WEIS, the order is not too high such that precision errors are caused. 

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I haven't found a great way to "trap" the error without running full WEIS optimizations with OpenFAST in the loop. 

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation