### PR TITLE
Bugfix for struct opt thicknesses

### DIFF
--- a/wisdem/rotorse/parametrize_rotor.py
+++ b/wisdem/rotorse/parametrize_rotor.py
@@ -226,6 +226,6 @@ class ParametrizeBladeStruct(ExplicitComponent):
                 else:
                     opt_m_interp = np.interp(inputs["s"], inputs["s_opt_te_ss"], inputs["te_ss_opt"])
             else:
-                opt_m_interp = inputs["layer_thickness_original"][i, :]
+                opt_m_interp = outputs["layer_thickness_param"][i, :]
 
             outputs["layer_thickness_param"][i, :] = opt_m_interp


### PR DESCRIPTION
## Purpose
Minor bugfix for structural thicknesses used in blade optimization.
To enable spar caps and TE reinforcements, need to draw from the correct output array instead of the input array for thicknesses.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation