### PR TITLE
Bug in double counting of rna mass

### DIFF
--- a/examples/09_floating/tlp_example.py
+++ b/examples/09_floating/tlp_example.py
@@ -149,7 +149,6 @@ prob["transition_node"] = prob["member0.joint2"]
 
 # Properties of rotor-nacelle-assembly (RNA)
 prob["rna_mass"] = 350e3
-prob["rna_I"] = 1e5 * np.array([1149.307, 220.354, 187.597, 0, 5.037, 0])
 prob["rna_cg"] = np.array([-1.132, 0, 0.509])
 prob["rna_F"] = np.array([1284744.196, 0, -112400.5527])
 prob["rna_M"] = np.array([3963732.762, 896380.8464, -346781.682])

--- a/wisdem/floatingse/floating_frame.py
+++ b/wisdem/floatingse/floating_frame.py
@@ -770,11 +770,8 @@ class FrameAnalysis(om.ExplicitComponent):
         self.add_input("transition_node", np.zeros(3), units="m")
         self.add_input("transition_piece_mass", 0.0, units="kg")
         self.add_input("transition_piece_I", np.zeros(6), units="kg*m**2")
-        self.add_input("rna_mass", 0.0, units="kg")
-        self.add_input("rna_cg", np.zeros(3), units="m")
         self.add_input("rna_F", np.zeros(3), units="N")
         self.add_input("rna_M", np.zeros(3), units="N*m")
-        self.add_input("rna_I", np.zeros(6), units="kg*m**2")
         self.add_input("mooring_neutral_load", np.zeros((n_attach, 3)), units="N")
         self.add_input("mooring_fairlead_joints", np.zeros((n_attach, 3)), units="m")
         self.add_input("mooring_stiffness", np.zeros((6, 6)), units="N/m")
@@ -813,11 +810,8 @@ class FrameAnalysis(om.ExplicitComponent):
         # Unpack variables
         opt = self.options["options"]
         n_attach = opt["mooring"]["n_attach"]
-        m_rna = float(inputs["rna_mass"])
-        cg_rna = inputs["rna_cg"]
         cb = inputs["platform_center_of_buoyancy"]
         V_total = inputs["platform_displacement"]
-        I_rna = inputs["rna_I"]
         I_trans = inputs["transition_piece_I"]
         m_variable = float(inputs["variable_ballast_mass"])
         cg_variable = inputs["variable_center_of_mass"]
@@ -891,10 +885,10 @@ class FrameAnalysis(om.ExplicitComponent):
                 m_trans += m_variable
                 cg_trans = np.zeros(3)
             add_gravity = True
-            mID = np.array([itrans, ihub], dtype=np.int_).flatten()
-            m_add = np.array([m_trans, m_rna]).flatten()
-            I_add = np.c_[I_trans, I_rna]
-            cg_add = np.c_[cg_trans, cg_rna]
+            mID = np.array([itrans], dtype=np.int_).flatten()
+            m_add = np.array([m_trans]).flatten()
+            I_add = np.c_[I_trans]
+            cg_add = np.c_[cg_trans]
             myframe.changeExtraNodeMass(
                 mID + 1,
                 m_add,

--- a/wisdem/glue_code/gc_WT_InitModel.py
+++ b/wisdem/glue_code/gc_WT_InitModel.py
@@ -862,7 +862,6 @@ def assign_tower_values(wt_opt, modeling_options, tower):
         elif modeling_options["flags"]["floating"]:
             wt_opt["floatingse.rna_mass"] = modeling_options["WISDEM"]["Loading"]["mass"]
             wt_opt["floatingse.rna_cg"] = modeling_options["WISDEM"]["Loading"]["center_of_mass"]
-            wt_opt["floatingse.rna_I"] = modeling_options["WISDEM"]["Loading"]["moment_of_inertia"]
             wt_opt["floatingse.rna_F"] = modeling_options["WISDEM"]["Loading"]["loads"][0]["force"]
             wt_opt["floatingse.rna_M"] = modeling_options["WISDEM"]["Loading"]["loads"][0]["moment"]
             wt_opt["floatingse.Uref"] = modeling_options["WISDEM"]["Loading"]["loads"][0]["velocity"]

--- a/wisdem/glue_code/glue_code.py
+++ b/wisdem/glue_code/glue_code.py
@@ -438,7 +438,6 @@ class WT_RNTA(om.Group):
             if modeling_options["flags"]["nacelle"]:
                 self.connect("drivese.base_F", "floatingse.rna_F")
                 self.connect("drivese.base_M", "floatingse.rna_M")
-                self.connect("drivese.rna_I_TT", "floatingse.rna_I")
                 self.connect("drivese.rna_cm", "floatingse.rna_cg")
                 self.connect("drivese.rna_mass", "floatingse.rna_mass")
 

--- a/wisdem/test/test_floatingse/test_floating.py
+++ b/wisdem/test/test_floatingse/test_floating.py
@@ -135,7 +135,6 @@ class TestOC3Mass(unittest.TestCase):
 
         # Properties of rotor-nacelle-assembly (RNA)
         prob["rna_mass"] = 350e3  # Mass [kg]
-        prob["rna_I"] = 1e5 * np.array([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
         prob["rna_cg"] = np.zeros(3)
         prob["rna_F"] = np.zeros(3)
         prob["rna_M"] = np.zeros(3)

--- a/wisdem/test/test_floatingse/test_frame.py
+++ b/wisdem/test/test_floatingse/test_frame.py
@@ -142,7 +142,6 @@ class TestPlatform(unittest.TestCase):
         self.inputs["tower_top_node"] = self.inputs["tower_nodes"][2, :]
         self.inputs["rna_mass"] = 1e4
         self.inputs["rna_cg"] = np.ones(3)
-        self.inputs["rna_I"] = 1e4 * np.arange(6)
         self.inputs["rna_F"] = np.array([1e2, 1e1, 0.0])
         self.inputs["rna_M"] = np.array([2e1, 2e2, 0.0])
         self.inputs["transition_piece_mass"] = 1e3
@@ -491,7 +490,6 @@ class TestGroup(unittest.TestCase):
         prob["mooring_fairlead_joints"] = np.array([[0.0, 0.0, 0.0], [0.5, 1.0, 0.0], [1.0, 0.0, 0.0]])
         prob["rna_mass"] = 1e4
         prob["rna_cg"] = np.ones(3)
-        prob["rna_I"] = 1e4 * np.arange(6)
         prob["rna_F"] = np.array([1e2, 1e1, 0.0])
         prob["rna_M"] = np.array([2e1, 2e2, 0.0])
         prob["transition_piece_mass"] = 1e3

--- a/wisdem/test/test_pyframe3dd/test_breakdown.py
+++ b/wisdem/test/test_pyframe3dd/test_breakdown.py
@@ -1,0 +1,145 @@
+import unittest
+import numpy as np
+import numpy.testing as npt
+from wisdem.pyframe3dd import Frame, Options, NodeData, ElementData, ReactionData, StaticLoadCase
+
+class TestBreakdown(unittest.TestCase):
+    
+    def testAll(self):
+        # Nodal data
+        ntop = 5
+        nbase = 10
+        nall = ntop + nbase - 1
+        xyz_top = np.c_[np.linspace(0.0, -10, ntop), np.zeros(ntop), 100*np.ones(ntop)]
+        xyz_base = np.c_[np.zeros((nbase,2)), np.linspace(0, 100, nbase)]
+        xyz_all = np.vstack( (xyz_base, xyz_top[1:,:]) )
+        
+        zero_top = np.zeros(ntop)
+        inode_top = np.arange(ntop, dtype=np.int_)+1
+        node_top = NodeData(inode_top, xyz_top[:,0], xyz_top[:,1], xyz_top[:,2], zero_top)
+        
+        zero_base = np.zeros(nbase)
+        inode_base = np.arange(nbase, dtype=np.int_)+1
+        node_base = NodeData(inode_base, xyz_base[:,0], xyz_base[:,1], xyz_base[:,2], zero_base)
+        
+        zero_all = np.zeros(nall)
+        inode_all = np.arange(nall, dtype=np.int_)+1
+        node_all = NodeData(inode_all, xyz_all[:,0], xyz_all[:,1], xyz_all[:,2], zero_all)
+
+        # Reactions
+        rnode = np.array([1], dtype=np.int_)
+        Kval = np.array([1], dtype=np.int_)
+        rigid = 1
+        reactions = ReactionData(rnode, Kval, Kval, Kval, Kval, Kval, Kval, rigid)
+
+        # Element data
+        top1 = np.ones(ntop-1)
+        base1 = np.ones(nbase-1)
+        all1 = np.ones(nall-1)
+        ielem_top = np.arange(1, ntop)
+        ielem_base = np.arange(1, nbase)
+        ielem_all = np.arange(1, nall)
+        N1_top = np.arange(ntop-1, dtype=np.int_)+1
+        N1_base = np.arange(nbase-1, dtype=np.int_)+1
+        N1_all = np.arange(nall-1, dtype=np.int_)+1
+        N2_top = N1_top + 1
+        N2_base = N1_base + 1
+        N2_all = N1_all + 1
+        Ax = 75.0
+        Asx = Asy = 50.0
+        J0 = 200.0
+        Ix = Iy = 100.0
+        E = 5e6
+        G = 5e6
+        density = 8e3
+        elem_top = ElementData(ielem_top, N1_top, N2_top,
+                               Ax*top1, Asx*top1, Asy*top1,
+                               J0*top1, Ix*top1, Iy*top1,
+                               E*top1, G*top1, 0.0*top1, density*top1)
+        elem_base = ElementData(ielem_base, N1_base, N2_base,
+                               Ax*base1, Asx*base1, Asy*base1,
+                               J0*base1, Ix*base1, Iy*base1,
+                               E*base1, G*base1, 0.0*base1, density*base1)
+        elem_all = ElementData(ielem_all, N1_all, N2_all,
+                               Ax*all1, Asx*all1, Asy*all1,
+                               J0*all1, Ix*all1, Iy*all1,
+                               E*all1, G*all1, 0.0*all1, density*all1)
+
+        # parameters
+        shear = False  # 1: include shear deformation
+        geom = False  # 1: include geometric stiffness
+        dx = -1.0  # x-axis increment for internal forces
+        options = Options(shear, geom, dx)
+
+        frame_top = Frame(node_top, reactions, elem_top, options)
+        frame_base = Frame(node_base, reactions, elem_base, options)
+        frame_all = Frame(node_all, reactions, elem_all, options)
+
+        # load case
+        gx = 0.0
+        gy = 0.0
+        gz = -9.81
+        load_top = StaticLoadCase(gx, gy, gz)
+        load_base = StaticLoadCase(gx, gy, gz)
+        load_all = StaticLoadCase(gx, gy, gz)
+
+        # pseudo-rotor loads
+        nF_top = [inode_top[-1]]
+        nF_base = [inode_base[-1]]
+        nF_all = [inode_all[-1]]
+        F = 1e5
+        M = 1e6
+        load_top.changePointLoads(nF_top, [F], [F], [F], [M], [M], [M])
+        load_all.changePointLoads(nF_all, [F], [F], [F], [M], [M], [M])
+
+        frame_top.addLoadCase(load_top)
+        frame_all.addLoadCase(load_all)
+
+        # Added mass
+        AN_top = [inode_top[-2]]
+        AN_all = [inode_all[-2]]
+        EMs = np.array([1e6])
+        EMxx = EMyy = EMzz = EMxy = EMxz = EMyz = np.array([0.0])
+        rhox = rhoy = rhoz = np.array([0.0])
+        addGravityLoad = True
+        frame_top.changeExtraNodeMass(AN_top, EMs, EMxx, EMyy, EMzz, EMxy, EMxz, EMyz, rhox, rhoy, rhoz, addGravityLoad)
+        frame_all.changeExtraNodeMass(AN_all, EMs, EMxx, EMyy, EMzz, EMxy, EMxz, EMyz, rhox, rhoy, rhoz, addGravityLoad)
+
+        # Run first models
+        disp_top, forces_top, rxns_top, _, _, modal_top = frame_top.run()
+        disp_all, forces_all, rxns_all, _, _, modal_all = frame_all.run()
+
+        # Transfer loads to base
+        load_base.changePointLoads(nF_base,
+                                   [-rxns_top.Fx],
+                                   [-rxns_top.Fy],
+                                   [-rxns_top.Fz],
+                                   [-rxns_top.Mxx],
+                                   [-rxns_top.Myy],
+                                   [-rxns_top.Mzz],
+                                   )
+        frame_base.addLoadCase(load_base)
+        disp_base, forces_base, rxns_base, _, _, modal_base = frame_base.run()
+
+        npt.assert_almost_equal(rxns_all.Fx, rxns_base.Fx, decimal=3)
+        npt.assert_almost_equal(rxns_all.Fy, rxns_base.Fy, decimal=3)
+        npt.assert_almost_equal(rxns_all.Fz, rxns_base.Fz, decimal=3)
+        npt.assert_almost_equal(rxns_all.Mxx, rxns_base.Mxx, decimal=2)
+        npt.assert_almost_equal(rxns_all.Myy, rxns_base.Myy, decimal=2)
+        npt.assert_almost_equal(rxns_all.Mzz, rxns_base.Mzz, decimal=2)
+        
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestBreakdown))
+    return suite
+
+
+if __name__ == "__main__":
+    result = unittest.TextTestRunner().run(suite())
+
+    if result.wasSuccessful():
+        exit(0)
+    else:
+        exit(1)
+    
+

--- a/wisdem/test/test_towerse/test_tower.py
+++ b/wisdem/test/test_towerse/test_tower.py
@@ -98,20 +98,8 @@ class TestTowerSE(unittest.TestCase):
         prob["mu_air"] = 1.7934e-5
         prob["shearExp"] = 0.2
         prob["wind.Uref"] = 15.0
-        prob["pre.rna_F"] = 1e3 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
-        prob["pre.rna_M"] = 1e4 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
+        prob["pre.rna_F"] = 1e3 * np.arange(2,5)
+        prob["pre.rna_M"] = 1e4 * np.arange(2,5)
         prob.run_model()
 
         # All other tests from above
@@ -138,17 +126,17 @@ class TestTowerSE(unittest.TestCase):
         npt.assert_equal(prob["pre.kty"], np.array([RIGID]))
         npt.assert_equal(prob["pre.ktz"], np.array([RIGID]))
 
-        npt.assert_equal(prob["pre.midx"], np.array([6, 0, 0]))
-        npt.assert_equal(prob["pre.m"], np.array([2e5, 0, 0]))
-        npt.assert_equal(prob["pre.mrhox"], np.array([-3.0, 0.0, 0.0]))
-        npt.assert_equal(prob["pre.mrhoy"], np.array([0.0, 0.0, 0.0]))
-        npt.assert_equal(prob["pre.mrhoz"], np.array([1.0, 0.0, 0.0]))
-        npt.assert_equal(prob["pre.mIxx"], np.array([1e5, 0.0, 0.0]))
-        npt.assert_equal(prob["pre.mIyy"], np.array([1e5, 0.0, 0.0]))
-        npt.assert_equal(prob["pre.mIzz"], np.array([2e5, 0.0, 0.0]))
-        npt.assert_equal(prob["pre.mIxy"], np.zeros(3))
-        npt.assert_equal(prob["pre.mIxz"], np.zeros(3))
-        npt.assert_equal(prob["pre.mIyz"], np.zeros(3))
+        npt.assert_equal(prob["pre.midx"], np.zeros(2))
+        npt.assert_equal(prob["pre.m"],  np.zeros(2))
+        npt.assert_equal(prob["pre.mrhox"], np.zeros(2))
+        npt.assert_equal(prob["pre.mrhoy"], np.zeros(2))
+        npt.assert_equal(prob["pre.mrhoz"], np.zeros(2))
+        npt.assert_equal(prob["pre.mIxx"], np.zeros(2))
+        npt.assert_equal(prob["pre.mIyy"], np.zeros(2))
+        npt.assert_equal(prob["pre.mIzz"], np.zeros(2))
+        npt.assert_equal(prob["pre.mIxy"], np.zeros(2))
+        npt.assert_equal(prob["pre.mIxz"], np.zeros(2))
+        npt.assert_equal(prob["pre.mIyz"], np.zeros(2))
 
         npt.assert_equal(prob["pre.plidx"], np.array([6]))
         npt.assert_equal(prob["pre.Fx"], np.array([2e3]))
@@ -218,20 +206,8 @@ class TestTowerSE(unittest.TestCase):
         prob["Hsig_wave"] = 0.0
         prob["Tsig_wave"] = 1e3
         prob["wind.Uref"] = 15.0
-        prob["pre.rna_F"] = 1e3 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
-        prob["pre.rna_M"] = 1e4 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
+        prob["pre.rna_F"] = 1e3 * np.arange(2,5)
+        prob["pre.rna_M"] = 1e4 * np.arange(2,5)
         prob.run_model()
 
         # All other tests from above
@@ -269,17 +245,17 @@ class TestTowerSE(unittest.TestCase):
         npt.assert_array_less(0.0, prob["pre.ktz"])
         npt.assert_equal(0.0, prob["pre.kz"][1:])
 
-        npt.assert_equal(prob["pre.midx"], np.array([12, 6, 0]))
-        npt.assert_equal(prob["pre.m"], np.array([2e5, 1e2, 0]))
-        npt.assert_equal(prob["pre.mrhox"], np.array([-3.0, 0.0, 0.0]))
-        npt.assert_equal(prob["pre.mrhoy"], np.array([0.0, 0.0, 0.0]))
-        npt.assert_equal(prob["pre.mrhoz"], np.array([1.0, 0.0, 0.0]))
-        npt.assert_equal(prob["pre.mIxx"], np.array([1e5, 1e2 * 25 * 0.5, 0]))
-        npt.assert_equal(prob["pre.mIyy"], np.array([1e5, 1e2 * 25 * 0.5, 0]))
-        npt.assert_equal(prob["pre.mIzz"], np.array([2e5, 1e2 * 25, 0]))
-        npt.assert_equal(prob["pre.mIxy"], np.zeros(3))
-        npt.assert_equal(prob["pre.mIxz"], np.zeros(3))
-        npt.assert_equal(prob["pre.mIyz"], np.zeros(3))
+        npt.assert_equal(prob["pre.midx"], np.array([6, 0]))
+        npt.assert_equal(prob["pre.m"], np.array([1e2, 0]))
+        npt.assert_equal(prob["pre.mrhox"], np.zeros(2))
+        npt.assert_equal(prob["pre.mrhoy"], np.zeros(2))
+        npt.assert_equal(prob["pre.mrhoz"], np.zeros(2))
+        npt.assert_equal(prob["pre.mIxx"], np.array([1e2 * 25 * 0.5, 0]))
+        npt.assert_equal(prob["pre.mIyy"], np.array([1e2 * 25 * 0.5, 0]))
+        npt.assert_equal(prob["pre.mIzz"], np.array([1e2 * 25, 0]))
+        npt.assert_equal(prob["pre.mIxy"], np.zeros(2))
+        npt.assert_equal(prob["pre.mIxz"], np.zeros(2))
+        npt.assert_equal(prob["pre.mIyz"], np.zeros(2))
 
         npt.assert_equal(prob["pre.plidx"], np.array([12]))
         npt.assert_equal(prob["pre.Fx"], np.array([2e3]))
@@ -288,8 +264,6 @@ class TestTowerSE(unittest.TestCase):
         npt.assert_equal(prob["pre.Mxx"], np.array([2e4]))
         npt.assert_equal(prob["pre.Myy"], np.array([3e4]))
         npt.assert_equal(prob["pre.Mzz"], np.array([4e4]))
-        npt.assert_almost_equal(prob["tower.base_F"], [4.61183362e04, 1.59353875e03, -2.94077236e07], 0)
-        npt.assert_almost_equal(prob["tower.base_M"], [-248566.38259147, -3286049.81237828, 40000.0], 0)
 
     def testProblemFixedPile_GBF(self):
         self.modeling_options["WISDEM"]["TowerSE"]["n_height_monopile"] = 3
@@ -349,20 +323,8 @@ class TestTowerSE(unittest.TestCase):
         prob["Hsig_wave"] = 0.0
         prob["Tsig_wave"] = 1e3
         prob["wind.Uref"] = 15.0
-        prob["pre.rna_F"] = 1e3 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
-        prob["pre.rna_M"] = 1e4 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
+        prob["pre.rna_F"] = 1e3 * np.arange(2,5)
+        prob["pre.rna_M"] = 1e4 * np.arange(2,5)
         prob.run_model()
 
         # All other tests from above
@@ -393,17 +355,17 @@ class TestTowerSE(unittest.TestCase):
         npt.assert_equal(prob["pre.kty"], RIGID)
         npt.assert_equal(prob["pre.ktz"], RIGID)
 
-        npt.assert_equal(prob["pre.midx"], np.array([12, 6, 0]))
-        npt.assert_equal(prob["pre.m"], np.array([2e5, 1e2, 1e4]))
-        npt.assert_equal(prob["pre.mrhox"], np.array([-3.0, 0.0, 0.0]))
-        npt.assert_equal(prob["pre.mrhoy"], np.array([0.0, 0.0, 0.0]))
-        npt.assert_equal(prob["pre.mrhoz"], np.array([1.0, 0.0, 0.0]))
-        npt.assert_equal(prob["pre.mIxx"], np.array([1e5, 1e2 * 25 * 0.5, 1e4 * 25 * 0.25]))
-        npt.assert_equal(prob["pre.mIyy"], np.array([1e5, 1e2 * 25 * 0.5, 1e4 * 25 * 0.25]))
-        npt.assert_equal(prob["pre.mIzz"], np.array([2e5, 1e2 * 25, 1e4 * 25 * 0.5]))
-        npt.assert_equal(prob["pre.mIxy"], np.zeros(3))
-        npt.assert_equal(prob["pre.mIxz"], np.zeros(3))
-        npt.assert_equal(prob["pre.mIyz"], np.zeros(3))
+        npt.assert_equal(prob["pre.midx"], np.array([6, 0]))
+        npt.assert_equal(prob["pre.m"], np.array([1e2, 1e4]))
+        npt.assert_equal(prob["pre.mrhox"], np.zeros(2))
+        npt.assert_equal(prob["pre.mrhoy"], np.zeros(2))
+        npt.assert_equal(prob["pre.mrhoz"], np.zeros(2))
+        npt.assert_equal(prob["pre.mIxx"], np.array([1e2 * 25 * 0.5, 1e4 * 25 * 0.25]))
+        npt.assert_equal(prob["pre.mIyy"], np.array([1e2 * 25 * 0.5, 1e4 * 25 * 0.25]))
+        npt.assert_equal(prob["pre.mIzz"], np.array([1e2 * 25, 1e4 * 25 * 0.5]))
+        npt.assert_equal(prob["pre.mIxy"], np.zeros(2))
+        npt.assert_equal(prob["pre.mIxz"], np.zeros(2))
+        npt.assert_equal(prob["pre.mIyz"], np.zeros(2))
 
         npt.assert_equal(prob["pre.plidx"], np.array([12]))
         npt.assert_equal(prob["pre.Fx"], np.array([2e3]))
@@ -413,8 +375,6 @@ class TestTowerSE(unittest.TestCase):
         npt.assert_equal(prob["pre.Myy"], np.array([3e4]))
         npt.assert_equal(prob["pre.Mzz"], np.array([4e4]))
 
-        npt.assert_almost_equal(prob["tower.base_F"], [3.74393291e04, 1.84264671e03, -3.39826364e07], 0)
-        npt.assert_almost_equal(prob["tower.base_M"], [-294477.83027742, -2732413.3684215, 40000.0], 0)
 
     def testAddedMassForces(self):
         self.modeling_options["WISDEM"]["TowerSE"]["n_height_monopile"] = 3
@@ -475,28 +435,11 @@ class TestTowerSE(unittest.TestCase):
         prob["Hsig_wave"] = 0.0
         prob["Tsig_wave"] = 1e3
         prob["wind.Uref"] = 15.0
-        prob["pre.rna_F"] = 1e3 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
-        prob["pre.rna_M"] = 1e4 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
+        prob["pre.rna_F"] = 1e3 * np.arange(2,5)
+        prob["pre.rna_M"] = 1e4 * np.arange(2,5)
         prob.run_model()
 
         myFz = copy.copy(prob["tower.tower_Fz"])
-
-        prob["rna_mass"] = 1e4
-        prob.run_model()
-        myFz[3:] -= 1e4 * g
-        npt.assert_almost_equal(prob["tower.tower_Fz"], myFz)
 
         prob["transition_piece_mass"] = 1e2
         prob.run_model()
@@ -797,37 +740,31 @@ class TestTowerSE(unittest.TestCase):
         npt.assert_almost_equal(prob["constr_d_to_t"], [168.23076923, 161.26373626])
         npt.assert_almost_equal(prob["constr_taper"], [0.8225, 0.78419453])
         npt.assert_almost_equal(prob["wind1.Uref"], [11.73732])
-        npt.assert_almost_equal(prob["tower1.f1"], [0.33214436], 5)
-        npt.assert_almost_equal(prob["tower1.top_deflection"], [0.6988131])
+        npt.assert_almost_equal(prob["tower1.f1"], [0.85223523], 5)
+        npt.assert_almost_equal(prob["tower1.top_deflection"], [0.71827368])
         npt.assert_almost_equal(
-            prob["post1.constr_stress"], [0.3844339, 0.3436128, 0.2856628, 0.2421312, 0.1121663, 0.0623614]
-        )
+            prob["post1.constr_stress"], [0.4087813, 0.3708382, 0.3169714, 0.2859883, 0.1630158, 0.0675306])
         npt.assert_almost_equal(
-            prob["post1.constr_global_buckling"], [0.5170422, 0.4829785, 0.4351583, 0.4221748, 0.3168518, 0.2755187]
-        )
+            prob["post1.constr_global_buckling"], [0.48831  , 0.4496673, 0.3963653, 0.3679457, 0.2518359, 0.1473065])
         npt.assert_almost_equal(
-            prob["post1.constr_shell_buckling"], [0.2371124, 0.1861889, 0.1282914, 0.1073705, 0.0295743, 0.0130323]
-        )
+            prob["post1.constr_shell_buckling"], [0.2644764, 0.2133211, 0.1544595, 0.1427571, 0.0527836, 0.0142973])
         npt.assert_almost_equal(prob["wind2.Uref"], [70.0])
-        npt.assert_almost_equal(prob["tower2.f1"], [0.33218936], 5)
-        npt.assert_almost_equal(prob["tower2.top_deflection"], [0.6440434])
+        npt.assert_almost_equal(prob["tower2.f1"], [0.8523348], 5)
+        npt.assert_almost_equal(prob["tower2.top_deflection"], [0.66504969])
         npt.assert_almost_equal(
-            prob["post2.constr_stress"], [0.3728837, 0.3137352, 0.2421504, 0.18487, 0.0662662, 0.0471034]
-        )
+            prob["post2.constr_stress"], [0.3979267, 0.3417342, 0.274272 , 0.2296022, 0.1168529, 0.0462037])
         npt.assert_almost_equal(
-            prob["post2.constr_global_buckling"], [0.5064959, 0.4570302, 0.3978452, 0.373074, 0.276448, 0.2668201]
-        )
+            prob["post2.constr_global_buckling"], [0.4783633, 0.4243923, 0.3597761, 0.3197055, 0.2124185, 0.1316666])
         npt.assert_almost_equal(
-            prob["post2.constr_shell_buckling"], [0.2258567, 0.1599288, 0.0970113, 0.0700506, 0.0156922, 0.0100741]
-        )
-        npt.assert_almost_equal(prob["tower1.base_F"][0], 1300347.476206353, 2)  # 1.29980269e06, 2)
+            prob["post2.constr_shell_buckling"], [0.2533651, 0.1859457, 0.1206584, 0.0997587, 0.032278 , 0.0099094])
+        npt.assert_almost_equal(prob["tower1.base_F"][0], 1300353.724137051, 2)  # 1.29980269e06, 2)
         npt.assert_array_less(np.abs(prob["tower1.base_F"][1]), 1e2, 2)
-        npt.assert_almost_equal(prob["tower1.base_F"][2], -6.31005811e06, 2)
-        npt.assert_almost_equal(prob["tower1.base_M"], [4.14775052e06, 1.10758024e08, -3.46827499e05], 0)
-        npt.assert_almost_equal(prob["tower2.base_F"][0], 1617231.046083178, 2)
+        npt.assert_almost_equal(prob["tower1.base_F"][2], -3509382.026583012, 2)
+        npt.assert_almost_equal(prob["tower1.base_M"], [4.01675306e+06, 1.11996416e+08, -3.46807162e+05], 0)
+        npt.assert_almost_equal(prob["tower2.base_F"][0], 1617238.0573503445, 2)
         npt.assert_array_less(np.abs(prob["tower2.base_F"][1]), 1e2, 2)
-        npt.assert_almost_equal(prob["tower2.base_F"][2], -6.27903939e06, 2)
-        npt.assert_almost_equal(prob["tower2.base_M"], [-1.76120197e06, 1.12569564e08, 1.47321336e05], 0)
+        npt.assert_almost_equal(prob["tower2.base_F"][2], -3478363.30626738, 2)
+        npt.assert_almost_equal(prob["tower2.base_M"], [-1.70559020e+06, 1.13959073e+08, 1.47312698e+05], 0)
 
         # Now regression on DNV-GL C202 methods
         self.modeling_options["WISDEM"]["TowerSE"]["buckling_method"] = "dnvgl"
@@ -843,37 +780,31 @@ class TestTowerSE(unittest.TestCase):
         npt.assert_almost_equal(prob["constr_d_to_t"], [168.23076923, 161.26373626])
         npt.assert_almost_equal(prob["constr_taper"], [0.8225, 0.78419453])
         npt.assert_almost_equal(prob["wind1.Uref"], [11.73732])
-        npt.assert_almost_equal(prob["tower1.f1"], [0.33214436], 5)
-        npt.assert_almost_equal(prob["tower1.top_deflection"], [0.6988131])
+        npt.assert_almost_equal(prob["tower1.f1"], [0.85223523], 5)
+        npt.assert_almost_equal(prob["tower1.top_deflection"], [0.71827368])
         npt.assert_almost_equal(
-            prob["post1.constr_stress"], [0.3844339, 0.3436128, 0.2856628, 0.2421312, 0.1121663, 0.0623614]
-        )
+            prob["post1.constr_stress"], [0.4087813, 0.3708382, 0.3169714, 0.2859883, 0.1630158, 0.0675306])
         npt.assert_almost_equal(
-            prob["post1.constr_global_buckling"], [0.6274373, 0.5691916, 0.4884754, 0.454831, 0.2769742, 0.2022617]
-        )
+            prob["post1.constr_global_buckling"], [0.592464 , 0.5315564, 0.4487466, 0.4038844, 0.2261382, 0.070537 ])
         npt.assert_almost_equal(
-            prob["post1.constr_shell_buckling"], [0.0357574, 0.0318343, 0.0281723, 0.0347622, 0.0310088, 0.0276982]
-        )
+            prob["post1.constr_shell_buckling"], [0.0178973, 0.0138168, 0.0099032, 0.0093709, 0.0052727, 0.0014409])
         npt.assert_almost_equal(prob["wind2.Uref"], [70.0])
-        npt.assert_almost_equal(prob["tower2.f1"], [0.33218936], 5)
-        npt.assert_almost_equal(prob["tower2.top_deflection"], [0.6440434])
+        npt.assert_almost_equal(prob["tower2.f1"], [0.8523348], 5)
+        npt.assert_almost_equal(prob["tower2.top_deflection"], [0.66504969])
         npt.assert_almost_equal(
-            prob["post2.constr_stress"], [0.3728837, 0.3137352, 0.2421504, 0.18487, 0.0662662, 0.0471034]
-        )
+            prob["post2.constr_stress"], [0.3979267, 0.3417342, 0.274272 , 0.2296022, 0.1168529, 0.0462037])
         npt.assert_almost_equal(
-            prob["post2.constr_global_buckling"], [0.616188, 0.532396, 0.4323648, 0.378272, 0.2126512, 0.1896404]
-        )
+            prob["post2.constr_global_buckling"], [0.5822361, 0.4964735, 0.3951091, 0.3315018, 0.1665172, 0.0474359])
         npt.assert_almost_equal(
-            prob["post2.constr_shell_buckling"], [0.0393843, 0.0397039, 0.0368479, 0.0463734, 0.0428983, 0.0394461]
-        )
-        npt.assert_almost_equal(prob["tower1.base_F"][0], 1300347.476206353, 2)  # 1.29980269e06, 2)
+            prob["post2.constr_shell_buckling"], [0.0213936, 0.0200053, 0.0166827, 0.0200927, 0.0162038, 0.0126214])
+        npt.assert_almost_equal(prob["tower1.base_F"][0], 1300353.724137051, 2)  # 1.29980269e06, 2)
         npt.assert_array_less(np.abs(prob["tower1.base_F"][1]), 1e2, 2)
-        npt.assert_almost_equal(prob["tower1.base_F"][2], -6.31005811e06, 2)
-        npt.assert_almost_equal(prob["tower1.base_M"], [4.14775052e06, 1.10758024e08, -3.46827499e05], 0)
-        npt.assert_almost_equal(prob["tower2.base_F"][0], 1617231.046083178, 2)
+        npt.assert_almost_equal(prob["tower1.base_F"][2], -3509382.026583012, 2)
+        npt.assert_almost_equal(prob["tower1.base_M"], [4.01675306e+06, 1.11996416e+08, -3.46807162e+05], 0)
+        npt.assert_almost_equal(prob["tower2.base_F"][0], 1617238.0573503445, 2)
         npt.assert_array_less(np.abs(prob["tower2.base_F"][1]), 1e2, 2)
-        npt.assert_almost_equal(prob["tower2.base_F"][2], -6.27903939e06, 2)
-        npt.assert_almost_equal(prob["tower2.base_M"], [-1.76120197e06, 1.12569564e08, 1.47321336e05], 0)
+        npt.assert_almost_equal(prob["tower2.base_F"][2], -3478363.30626738, 2)
+        npt.assert_almost_equal(prob["tower2.base_M"], [-1.70559020e+06, 1.13959073e+08, 1.47312698e+05], 0)
 
 
 def suite():

--- a/wisdem/test/test_towerse/test_tower_struct.py
+++ b/wisdem/test/test_towerse/test_tower_struct.py
@@ -72,20 +72,8 @@ class TestStruct(unittest.TestCase):
         self.inputs["gravity_foundation_I"] = np.zeros(6)
         self.inputs["gravity_foundation_mass"] = 0.0
         self.inputs["suctionpile_depth"] = 0.0
-        self.inputs["rna_F"] = 1e5 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
-        self.inputs["rna_M"] = 1e6 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
+        self.inputs["rna_F"] = 1e5 * np.arange(2,5)
+        self.inputs["rna_M"] = 1e6 * np.arange(2,5)
         self.inputs["E"] = 1e9 * np.ones(2)
         self.inputs["G"] = 1e8 * np.ones(2)
         self.inputs["sigma_y"] = 1e8 * np.ones(2)
@@ -101,17 +89,17 @@ class TestStruct(unittest.TestCase):
         npt.assert_equal(self.outputs["kty"], np.array([RIGID]))
         npt.assert_equal(self.outputs["ktz"], np.array([RIGID]))
 
-        npt.assert_equal(self.outputs["midx"], np.array([6, 0, 0]))
-        npt.assert_equal(self.outputs["m"], np.array([1e5, 0, 0]))
-        npt.assert_equal(self.outputs["mrhox"], np.array([-3.0, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mrhoy"], np.array([0.0, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mrhoz"], np.array([1.0, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mIxx"], np.array([1e5, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mIyy"], np.array([1e5, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mIzz"], np.array([2e5, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mIxy"], np.zeros(3))
-        npt.assert_equal(self.outputs["mIxz"], np.zeros(3))
-        npt.assert_equal(self.outputs["mIyz"], np.zeros(3))
+        npt.assert_equal(self.outputs["midx"], np.zeros(2))
+        npt.assert_equal(self.outputs["m"], np.zeros(2))
+        npt.assert_equal(self.outputs["mrhox"], np.zeros(2))
+        npt.assert_equal(self.outputs["mrhoy"], np.zeros(2))
+        npt.assert_equal(self.outputs["mrhoz"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIxx"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIyy"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIzz"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIxy"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIxz"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIyz"], np.zeros(2))
 
         npt.assert_equal(self.outputs["plidx"], np.array([6]))
         npt.assert_equal(self.outputs["Fx"], np.array([2e5]))
@@ -130,20 +118,8 @@ class TestStruct(unittest.TestCase):
         self.inputs["transition_piece_height"] = 10.0
         self.inputs["gravity_foundation_mass"] = 0.0  # 1e4
         self.inputs["suctionpile_depth"] = 30.0
-        self.inputs["rna_F"] = 1e5 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
-        self.inputs["rna_M"] = 1e6 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
+        self.inputs["rna_F"] = 1e5 * np.arange(2,5)
+        self.inputs["rna_M"] = 1e6 * np.arange(2,5)
         self.inputs["k_soil"] = (20.0 + np.arange(6))[np.newaxis, :] * np.ones((2, 6))
         self.inputs["z_soil"] = np.r_[-30.0, 0.0]
 
@@ -158,17 +134,17 @@ class TestStruct(unittest.TestCase):
         npt.assert_equal(self.outputs["kty"], RIGID)
         npt.assert_equal(self.outputs["ktz"], RIGID)
 
-        npt.assert_equal(self.outputs["midx"], np.array([12, 7, 0]))
-        npt.assert_equal(self.outputs["m"], np.array([1e5, 1e3, 0.0]))
-        npt.assert_equal(self.outputs["mrhox"], np.array([-3.0, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mrhoy"], np.array([0.0, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mrhoz"], np.array([1.0, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mIxx"], np.array([1e5, 1e3 * 9 * 0.5, 0]))
-        npt.assert_equal(self.outputs["mIyy"], np.array([1e5, 1e3 * 9 * 0.5, 0]))
-        npt.assert_equal(self.outputs["mIzz"], np.array([2e5, 1e3 * 9, 0]))
-        npt.assert_equal(self.outputs["mIxy"], np.zeros(3))
-        npt.assert_equal(self.outputs["mIxz"], np.zeros(3))
-        npt.assert_equal(self.outputs["mIyz"], np.zeros(3))
+        npt.assert_equal(self.outputs["midx"], np.array([7, 0]))
+        npt.assert_equal(self.outputs["m"], np.array([1e3, 0.0]))
+        npt.assert_equal(self.outputs["mrhox"], np.zeros(2))
+        npt.assert_equal(self.outputs["mrhoy"], np.zeros(2))
+        npt.assert_equal(self.outputs["mrhoz"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIxx"], np.array([1e3 * 9 * 0.5, 0]))
+        npt.assert_equal(self.outputs["mIyy"], np.array([1e3 * 9 * 0.5, 0]))
+        npt.assert_equal(self.outputs["mIzz"], np.array([1e3 * 9, 0]))
+        npt.assert_equal(self.outputs["mIxy"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIxz"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIyz"], np.zeros(2))
 
         npt.assert_equal(self.outputs["plidx"], np.array([12]))
         npt.assert_equal(self.outputs["Fx"], np.array([2e5]))
@@ -187,20 +163,8 @@ class TestStruct(unittest.TestCase):
         self.inputs["transition_piece_height"] = 10.0
         self.inputs["gravity_foundation_mass"] = 0.0  # 1e4
         self.inputs["suctionpile_depth"] = 30.0
-        self.inputs["rna_F"] = 1e5 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
-        self.inputs["rna_M"] = 1e6 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
+        self.inputs["rna_F"] = 1e5 * np.arange(2,5)
+        self.inputs["rna_M"] = 1e6 * np.arange(2,5)
         self.inputs["k_soil"] = (20.0 + np.arange(6))[np.newaxis, :] * np.ones((2, 6))
         self.inputs["z_soil"] = np.r_[-30.0, 0.0]
 
@@ -215,17 +179,17 @@ class TestStruct(unittest.TestCase):
         npt.assert_equal(self.outputs["kty"], 23.0)
         npt.assert_equal(self.outputs["ktz"], 25.0)
 
-        npt.assert_equal(self.outputs["midx"], np.array([12, 7, 0]))
-        npt.assert_equal(self.outputs["m"], np.array([1e5, 1e3, 0.0]))
-        npt.assert_equal(self.outputs["mrhox"], np.array([-3.0, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mrhoy"], np.array([0.0, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mrhoz"], np.array([1.0, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mIxx"], np.array([1e5, 1e3 * 9 * 0.5, 0]))
-        npt.assert_equal(self.outputs["mIyy"], np.array([1e5, 1e3 * 9 * 0.5, 0]))
-        npt.assert_equal(self.outputs["mIzz"], np.array([2e5, 1e3 * 9, 0]))
-        npt.assert_equal(self.outputs["mIxy"], np.zeros(3))
-        npt.assert_equal(self.outputs["mIxz"], np.zeros(3))
-        npt.assert_equal(self.outputs["mIyz"], np.zeros(3))
+        npt.assert_equal(self.outputs["midx"], np.array([7, 0]))
+        npt.assert_equal(self.outputs["m"], np.array([1e3, 0.0]))
+        npt.assert_equal(self.outputs["mrhox"], np.zeros(2))
+        npt.assert_equal(self.outputs["mrhoy"], np.zeros(2))
+        npt.assert_equal(self.outputs["mrhoz"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIxx"], np.array([1e3 * 9 * 0.5, 0]))
+        npt.assert_equal(self.outputs["mIyy"], np.array([1e3 * 9 * 0.5, 0]))
+        npt.assert_equal(self.outputs["mIzz"], np.array([1e3 * 9, 0]))
+        npt.assert_equal(self.outputs["mIxy"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIxz"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIyz"], np.zeros(2))
 
         npt.assert_equal(self.outputs["plidx"], np.array([12]))
         npt.assert_equal(self.outputs["Fx"], np.array([2e5]))
@@ -245,20 +209,8 @@ class TestStruct(unittest.TestCase):
         self.inputs["gravity_foundation_I"] = 0.5 * 1e4 * 9 * np.r_[0.5, 0.5, 1.0, np.zeros(3)]
         self.inputs["gravity_foundation_mass"] = 1e4
         self.inputs["suctionpile_depth"] = 0.0
-        self.inputs["rna_F"] = 1e5 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
-        self.inputs["rna_M"] = 1e6 * np.array(
-            [
-                2.0,
-                3.0,
-                4.0,
-            ]
-        )
+        self.inputs["rna_F"] = 1e5 * np.arange(2,5)
+        self.inputs["rna_M"] = 1e6 * np.arange(2,5)
         self.inputs["k_soil"] = (20.0 + np.arange(6))[np.newaxis, :] * np.ones((2, 6))
         self.inputs["z_soil"] = np.r_[-30.0, 0.0]
 
@@ -273,17 +225,17 @@ class TestStruct(unittest.TestCase):
         npt.assert_equal(self.outputs["kty"], np.array([RIGID]))
         npt.assert_equal(self.outputs["ktz"], np.array([RIGID]))
 
-        npt.assert_equal(self.outputs["midx"], np.array([12, 7, 0]))
-        npt.assert_equal(self.outputs["m"], np.array([1e5, 1e3, 1e4]))
-        npt.assert_equal(self.outputs["mrhox"], np.array([-3.0, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mrhoy"], np.array([0.0, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mrhoz"], np.array([1.0, 0.0, 0.0]))
-        npt.assert_equal(self.outputs["mIxx"], np.array([1e5, 1e3 * 9 * 0.5, 1e4 * 9 * 0.25]))
-        npt.assert_equal(self.outputs["mIyy"], np.array([1e5, 1e3 * 9 * 0.5, 1e4 * 9 * 0.25]))
-        npt.assert_equal(self.outputs["mIzz"], np.array([2e5, 1e3 * 9, 1e4 * 9 * 0.5]))
-        npt.assert_equal(self.outputs["mIxy"], np.zeros(3))
-        npt.assert_equal(self.outputs["mIxz"], np.zeros(3))
-        npt.assert_equal(self.outputs["mIyz"], np.zeros(3))
+        npt.assert_equal(self.outputs["midx"], np.array([7, 0]))
+        npt.assert_equal(self.outputs["m"], np.array([1e3, 1e4]))
+        npt.assert_equal(self.outputs["mrhox"], np.zeros(2))
+        npt.assert_equal(self.outputs["mrhoy"], np.zeros(2))
+        npt.assert_equal(self.outputs["mrhoz"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIxx"], np.array([1e3 * 9 * 0.5, 1e4 * 9 * 0.25]))
+        npt.assert_equal(self.outputs["mIyy"], np.array([1e3 * 9 * 0.5, 1e4 * 9 * 0.25]))
+        npt.assert_equal(self.outputs["mIzz"], np.array([1e3 * 9, 1e4 * 9 * 0.5]))
+        npt.assert_equal(self.outputs["mIxy"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIxz"], np.zeros(2))
+        npt.assert_equal(self.outputs["mIyz"], np.zeros(2))
 
         npt.assert_equal(self.outputs["plidx"], np.array([12]))
         npt.assert_equal(self.outputs["Fx"], np.array([2e5]))

--- a/wisdem/towerse/tower.py
+++ b/wisdem/towerse/tower.py
@@ -183,9 +183,6 @@ class TowerSE(om.Group):
             self.set_input_defaults("G_soil", 0.0, units="N/m**2")
             self.set_input_defaults("nu_soil", 0.0)
         self.set_input_defaults("sigma_y", np.zeros(n_height - 1), units="N/m**2")
-        self.set_input_defaults("rna_mass", 0.0, units="kg")
-        self.set_input_defaults("rna_cg", np.zeros(3), units="m")
-        self.set_input_defaults("rna_I", np.zeros(6), units="kg*m**2")
         self.set_input_defaults("life", 0.0)
 
         # Load baseline discretization
@@ -239,9 +236,6 @@ class TowerSE(om.Group):
                     "gravity_foundation_I",
                     "z_full",
                     "suctionpile_depth",
-                    ("mass", "rna_mass"),
-                    ("mrho", "rna_cg"),
-                    ("mI", "rna_I"),
                 ],
             )
             self.add_subsystem(
@@ -249,7 +243,7 @@ class TowerSE(om.Group):
                 ts.CylinderFrame3DD(
                     nFull=nFull,
                     nK=4 if monopile and not mod_opt["gravity_foundation"] else 1,
-                    nMass=3,
+                    nMass=2,
                     nPL=1,
                     frame3dd_opt=frame3dd_opt,
                 ),

--- a/wisdem/towerse/tower_props.py
+++ b/wisdem/towerse/tower_props.py
@@ -925,7 +925,7 @@ class TurbineMass(om.ExplicitComponent):
         self.declare_partials("turbine_mass", ["monopile_mass", "rna_mass", "tower_mass"], val=1.0)
 
     def compute(self, inputs, outputs):
-        outputs["turbine_mass"] = inputs["rna_mass"] + inputs["tower_mass"] + inputs["monopile_mass"]
+        outputs["turbine_mass"] = inputs["rna_mass"] + inputs["tower_mass"]
 
         cg_rna = inputs["rna_cg"] + np.r_[0.0, 0.0, inputs["hub_height"]]
         cg_tower = np.r_[0.0, 0.0, inputs["tower_center_of_mass"]]

--- a/wisdem/towerse/tower_struct.py
+++ b/wisdem/towerse/tower_struct.py
@@ -21,12 +21,6 @@ class TowerPreFrame(om.ExplicitComponent):
     ----------
     z_full : numpy array[nFull], [m]
         location along tower. start at bottom and go to top
-    mass : float, [kg]
-        added mass
-    mI : numpy array[6], [kg*m**2]
-        mass moment of inertia about some point p [xx yy zz xy xz yz]
-    mrho : numpy array[3], [m]
-        xyz-location of p relative to node
     suctionpile_depth : float, [m]
         Depth of monopile below sea floor
     transition_piece_mass : float, [kg]
@@ -112,9 +106,6 @@ class TowerPreFrame(om.ExplicitComponent):
         self.add_input("z_full", np.zeros(nFull), units="m")
 
         # extra mass
-        self.add_input("mass", 0.0, units="kg")
-        self.add_input("mI", np.zeros(6), units="kg*m**2")
-        self.add_input("mrho", np.zeros(3), units="m")
         self.add_input("transition_piece_mass", 0.0, units="kg")
         self.add_input("transition_piece_I", np.zeros(6), units="kg*m**2")
         self.add_input("gravity_foundation_I", np.zeros(6), units="kg*m**2")
@@ -141,7 +132,7 @@ class TowerPreFrame(om.ExplicitComponent):
         self.add_output("ktz", np.zeros(nK), units="N/m")
 
         # extra mass
-        nMass = 3
+        nMass = 2
         self.add_output("midx", np.zeros(nMass, dtype=np.int_))
         self.add_output("m", np.zeros(nMass), units="kg")
         self.add_output("mIxx", np.zeros(nMass), units="kg*m**2")
@@ -199,22 +190,20 @@ class TowerPreFrame(om.ExplicitComponent):
 
         # Prepare RNA, transition piece, and gravity foundation (if any applicable) for "extra node mass"
         itrans = util.find_nearest(z, inputs["transition_piece_height"])
-        mtrans = inputs["transition_piece_mass"]
-        Itrans = inputs["transition_piece_I"]
-        mgrav = inputs["gravity_foundation_mass"]
-        Igrav = inputs["gravity_foundation_I"]
+        mtrans = float(inputs["transition_piece_mass"])
+        Itrans = inputs["transition_piece_I"].flatten()
+        mgrav = float(inputs["gravity_foundation_mass"])
+        Igrav = inputs["gravity_foundation_I"].flatten()
         # Note, need len()-1 because Frame3DD crashes if mass add at end
-        outputs["midx"] = np.array([nFull - 1, itrans, 0], dtype=np.int_)
-        outputs["m"] = np.array([inputs["mass"], mtrans, mgrav]).flatten()
-        outputs["mIxx"] = np.array([inputs["mI"][0], Itrans[0], Igrav[0]]).flatten()
-        outputs["mIyy"] = np.array([inputs["mI"][1], Itrans[1], Igrav[1]]).flatten()
-        outputs["mIzz"] = np.array([inputs["mI"][2], Itrans[2], Igrav[2]]).flatten()
-        outputs["mIxy"] = np.array([inputs["mI"][3], Itrans[3], Igrav[3]]).flatten()
-        outputs["mIxz"] = np.array([inputs["mI"][4], Itrans[4], Igrav[4]]).flatten()
-        outputs["mIyz"] = np.array([inputs["mI"][5], Itrans[5], Igrav[5]]).flatten()
-        outputs["mrhox"] = np.array([inputs["mrho"][0], 0.0, 0.0]).flatten()
-        outputs["mrhoy"] = np.array([inputs["mrho"][1], 0.0, 0.0]).flatten()
-        outputs["mrhoz"] = np.array([inputs["mrho"][2], 0.0, 0.0]).flatten()
+        outputs["midx"] = np.array([itrans, 0], dtype=np.int_)
+        outputs["m"] = np.array([mtrans, mgrav])
+        outputs["mIxx"] = np.array([Itrans[0], Igrav[0]])
+        outputs["mIyy"] = np.array([Itrans[1], Igrav[1]])
+        outputs["mIzz"] = np.array([Itrans[2], Igrav[2]])
+        outputs["mIxy"] = np.array([Itrans[3], Igrav[3]])
+        outputs["mIxz"] = np.array([Itrans[4], Igrav[4]])
+        outputs["mIyz"] = np.array([Itrans[5], Igrav[5]])
+        outputs["mrhox"] = outputs["mrhoy"] = outputs["mrhoz"] = np.zeros(2)
 
         # Prepare point forces at RNA node
         outputs["plidx"] = np.array([nFull - 1], dtype=np.int_)  # -1 b/c same reason as above


### PR DESCRIPTION
## Purpose
Embarrassing to catch this a year late, but once we moved to using Frame3DD for the drivetrain, RNA mass is accounted for in the tower top forces & moments.  Adding it in again in the tower calcs meant we are double counting it.  I made a quick Frame3DD example unit test to ensure that this is the case.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [x] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation