### PR TITLE
Include pip in CI (for Linux/Mac), more robust conda instructions

### DIFF
--- a/.github/workflows/CI_WISDEM.yml
+++ b/.github/workflows/CI_WISDEM.yml
@@ -51,10 +51,18 @@ jobs:
           python setup.py develop
 
       # Install WISDEM with pip
-      - name: Install WISDEM with pip
+      - name: Install WISDEM with pip for Unix
+        if: false == contains( matrix.os, 'windows')
         shell: pwsh
         run: |
-          pip install -e .
+          pip install -vv --no-deps -e .
+
+      # Install WISDEM with pip
+      - name: Install WISDEM with pip for Windows
+        if: contains( matrix.os, 'windows')
+        shell: pwsh
+        run: |
+          pip install -vv --no-deps --global-option --compiler=unix .
 
       # Run all tests
       - name: Run tests

--- a/.github/workflows/CI_WISDEM.yml
+++ b/.github/workflows/CI_WISDEM.yml
@@ -32,7 +32,7 @@ jobs:
         #shell: pwsh # putting in a shell command makes for compile linking problems later
         # (if you use the shell here, cannot use 'compiler' package)
         run: |
-          conda install -y petsc4py mpi4py compilers nlopt
+          conda install -y petsc4py mpi4py compilers
 
       # Install dependencies of WISDEM specific to windows
       - name: Add dependencies windows specific
@@ -44,11 +44,17 @@ jobs:
       #- name: Setup tmate session
       #  uses: mxschmitt/action-tmate@v3
 
-      # Install WISDEM
-      - name: Install WISDEM
+      # Install WISDEM with setup
+      - name: Install WISDEM with setup
         shell: pwsh
         run: |
           python setup.py develop
+
+      # Install WISDEM with pip
+      - name: Install WISDEM with pip
+        shell: pwsh
+        run: |
+          pip install -e .
 
       # Run all tests
       - name: Run tests

--- a/.github/workflows/CI_WISDEM.yml
+++ b/.github/workflows/CI_WISDEM.yml
@@ -58,11 +58,11 @@ jobs:
           pip install -vv --no-deps -e .
 
       # Install WISDEM with pip
-      - name: Install WISDEM with pip for Windows
-        if: contains( matrix.os, 'windows')
-        shell: pwsh
-        run: |
-          pip install -vv --no-deps --global-option --compiler=unix .
+      #- name: Install WISDEM with pip for Windows
+      #  if: contains( matrix.os, 'windows')
+      #  shell: pwsh
+      #  run: |
+      #    pip install -vv --no-deps --global-option --compiler=unix .
 
       # Run all tests
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The installation instructions below use the environment name, "wisdem-env," but 
         git clone https://github.com/WISDEM/WISDEM.git
         cd WISDEM
         git checkout develop                         # If you want to switch WISDEM branches
-        pip install -e .
+        python setup.py develop
 
 
 3. OPTIONAL: Install pyOptSparse, a package that provides a handful of additional optimization solvers and has OpenMDAO support:

--- a/README.md
+++ b/README.md
@@ -48,17 +48,16 @@ The installation instructions below use the environment name, "wisdem-env," but 
         conda create -y --name wisdem-env python=3.8
         conda activate wisdem-env
 
-2.  In order to directly use the examples in the repository and peek at the code when necessary, we recommend all users install WISDEM in *developer* mode.  This is done by first installing WISDEM as a conda package to easily satisfy all dependencies, but then removing the WISDEM conda package and reinstalling from the Github source code.  Note the differences between Windows and Mac/Linux build systems. For Linux, we recommend using the native compilers (for example, gcc and gfortran in the default GNU suite).
+2.  In order to directly use the examples in the repository and peek at the code when necessary, we recommend all users install WISDEM in *developer / editable* mode using the instructions here.  If you really just want to use WISDEM as a library and lean on the documentation, you can always do `conda install wisdem` and be done.  Note the differences between Windows and Mac/Linux build systems. For Linux, we recommend using the native compilers (for example, gcc and gfortran in the default GNU suite).
 
-        conda install -y wisdem git
-        conda remove -y --force wisdem
+        conda install -y cython git jsonschema make matplotlib nlopt numpy openmdao openpyxl pandas pip pyside2 pytest python-benedict pyyaml ruamel_yaml scipy setuptools simpy sortedcontainers swig
         conda install -y compilers                   # (Mac only)
         conda install -y m2w64-toolchain libpython   # (Windows only)
-        pip install simpy marmot-agents nlopt
+        pip install marmot-agents
         git clone https://github.com/WISDEM/WISDEM.git
         cd WISDEM
         git checkout develop                         # If you want to switch WISDEM branches
-        python setup.py develop
+        pip install -e .
 
 
 3. OPTIONAL: Install pyOptSparse, a package that provides a handful of additional optimization solvers and has OpenMDAO support:

--- a/environment.yml
+++ b/environment.yml
@@ -26,11 +26,11 @@ dependencies:
   - pyyaml
   - ruamel_yaml
   - scipy
-  - setuptools==58.4.0
+  - setuptools
+  - simpy
   - sortedcontainers
   - swig
   - pip:
-    - simpy
     - marmot-agents
 # Needs to be done outside of environment file:
 #  - m2w64-toolchain # [win]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ bemExt = Extension(
     extra_compile_args=["-O2", "-fPIC", "-std=c11"],
 )
 pyframeExt = Extension(
-    "wisdem.pyframe3dd._pyframe3dd", 
+    "wisdem.pyframe3dd._pyframe3dd",
     sources=glob.glob(os.path.join("wisdem", "pyframe3dd", "src", "*.c")),
     extra_compile_args=["-O2", "-fPIC", "-std=c11"],
 )
@@ -43,7 +43,6 @@ setup(
         "openmdao>=3.4",
         "openpyxl",
         "pandas",
-        "pyside2",
         "pytest",
         "python-benedict",
         "pyyaml",

--- a/wisdem/test/test_optimization_drivers/test_nlopt_driver.py
+++ b/wisdem/test/test_optimization_drivers/test_nlopt_driver.py
@@ -10,11 +10,10 @@ from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import run_driver
 from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDerivativesGrouped
 from openmdao.test_suite.groups.sin_fitter import SineFitter
+from wisdem.optimization_drivers.nlopt_driver import NLoptDriver
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.simple_comps import NonSquareArrayComp
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
-
-from wisdem.optimization_drivers.nlopt_driver import NLoptDriver
 
 try:
     import nlopt
@@ -1001,9 +1000,11 @@ class TestNLoptDriver(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             totals = prob.check_totals(method="fd", out_stream=False)
 
-        expected_msg = "Problem: run_model must be called before total derivatives can be checked."
+        # expected_msg = "Problem: run_model must be called before total derivatives can be checked."
+        expected_msg = "run_model must be called before total derivatives can be checked."
 
-        self.assertEqual(expected_msg, str(cm.exception))
+        # self.assertEqual(expected_msg, str(cm.exception))
+        self.assertTrue(str(cm.exception).find(expected_msg) >= 0)
 
     def test_LN_COBYLA_linear_constraint(self):
         # Bug where NLoptDriver tried to compute and cache the constraint derivatives for the


### PR DESCRIPTION
## Purpose
Updates the conda install instructions to be a little more robust and includes `pip install` in our CI builds.  I have also removed `pyside2` from the `setup.py` file as that is the cause of Issue #350 

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation