### PR TITLE
Rely on conda version of pyoptsparse

### DIFF
--- a/.github/workflows/CI_WISDEM.yml
+++ b/.github/workflows/CI_WISDEM.yml
@@ -32,7 +32,7 @@ jobs:
         #shell: pwsh # putting in a shell command makes for compile linking problems later
         # (if you use the shell here, cannot use 'compiler' package)
         run: |
-          conda install -y petsc4py mpi4py compilers
+          conda install -y petsc4py mpi4py compilers pyoptsparse
 
       # Install dependencies of WISDEM specific to windows
       - name: Add dependencies windows specific

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ The installation instructions below use the environment name, "wisdem-env," but 
 
 2.  In order to directly use the examples in the repository and peek at the code when necessary, we recommend all users install WISDEM in *developer / editable* mode using the instructions here.  If you really just want to use WISDEM as a library and lean on the documentation, you can always do `conda install wisdem` and be done.  Note the differences between Windows and Mac/Linux build systems. For Linux, we recommend using the native compilers (for example, gcc and gfortran in the default GNU suite).
 
-        conda install -y cython git jsonschema make matplotlib nlopt numpy openmdao openpyxl pandas pip pyside2 pyoptsparse pytest python-benedict pyyaml ruamel_yaml scipy setuptools simpy sortedcontainers swig
-        conda install -y compilers                   # (Mac only)
+        conda install -y cython git jsonschema make matplotlib nlopt numpy openmdao openpyxl pandas pip pyside2 pytest python-benedict pyyaml ruamel_yaml scipy setuptools simpy sortedcontainers swig
+        conda install -y pyoptsparse                 # (Linux only)
+        conda install -y compilers pyoptsparse       # (Mac only)
         conda install -y m2w64-toolchain libpython   # (Windows only)
         pip install marmot-agents
         git clone https://github.com/WISDEM/WISDEM.git

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The installation instructions below use the environment name, "wisdem-env," but 
 
 2.  In order to directly use the examples in the repository and peek at the code when necessary, we recommend all users install WISDEM in *developer / editable* mode using the instructions here.  If you really just want to use WISDEM as a library and lean on the documentation, you can always do `conda install wisdem` and be done.  Note the differences between Windows and Mac/Linux build systems. For Linux, we recommend using the native compilers (for example, gcc and gfortran in the default GNU suite).
 
-        conda install -y cython git jsonschema make matplotlib nlopt numpy openmdao openpyxl pandas pip pyside2 pytest python-benedict pyyaml ruamel_yaml scipy setuptools simpy sortedcontainers swig
+        conda install -y cython git jsonschema make matplotlib nlopt numpy openmdao openpyxl pandas pip pyside2 pyoptsparse pytest python-benedict pyyaml ruamel_yaml scipy setuptools simpy sortedcontainers swig
         conda install -y compilers                   # (Mac only)
         conda install -y m2w64-toolchain libpython   # (Windows only)
         pip install marmot-agents
@@ -58,12 +58,6 @@ The installation instructions below use the environment name, "wisdem-env," but 
         cd WISDEM
         git checkout develop                         # If you want to switch WISDEM branches
         python setup.py develop
-
-
-3. OPTIONAL: Install pyOptSparse, a package that provides a handful of additional optimization solvers and has OpenMDAO support:
-
-        git clone https://github.com/evan-gaertner/pyoptsparse.git
-        pip install -e pyoptsparse
 
 
 **NOTE:** To use WISDEM again after installation is complete, you will always need to activate the conda environment first with `conda activate wisdem-env`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,7 +13,7 @@ Setup and activate the Anaconda environment from a prompt (Anaconda3 Power Shell
 .. code-block:: bash
 
     conda config --add channels conda-forge
-    conda create -y --name wisdem-env python=3.7
+    conda create -y --name wisdem-env python=3.8
     conda activate wisdem-env
 
 Note that any future occasion on which you wish to use WISDEM, you will only have to start with ``conda activate wisdem-env``.
@@ -21,13 +21,12 @@ Note that any future occasion on which you wish to use WISDEM, you will only hav
 Install WISDEM
 ^^^^^^^^^^^^^^
 
-In order to directly use the examples in the repository and peek at the code when necessary, we recommend all users install WISDEM in *developer* mode.  This is done by first installing WISDEM as a conda package to easily satisfy all dependencies, but then removing the WISDEM conda package and reinstalling from the Github source code.  Note the differences between Windows and Mac build systems.  For Linux, we recommend using the native compilers (for example, gcc and gfortran in the default GNU suite).
+In order to directly use the examples in the repository and peek at the code when necessary, we recommend all users install WISDEM in *developer* mode.  This is done by first installing WISDEM dependencies and then installing WISDEM from the Github source code.  Note the differences between Windows and Mac build systems.  For Linux, we recommend using the native compilers (for example, gcc and gfortran in the default GNU suite).
 
 .. code-block:: bash
 
-    conda install -y wisdem git
-    conda remove --force wisdem
-    pip install simpy marmot-agents nlopt
+    conda install -y cython git jsonschema make matplotlib nlopt numpy openmdao openpyxl pandas pip pyside2 pyoptsparse pytest python-benedict pyyaml ruamel_yaml scipy setuptools simpy sortedcontainers swig
+    pip install marmot-agents
 
 For Mac systems:
 
@@ -49,16 +48,6 @@ Finally, for all systems:
     cd WISDEM
     git checkout develop
     pip install -e .
-
-Install pyOptSparse (`Optional`)
-""""""""""""""""""""""""""""""""
-
-`pyOptSparse <https://github.com/mdolab/pyoptsparse>`_ is a package that provides additional optimization solvers with OpenMDAO support:
-
-.. code-block:: bash
-
-    git clone https://github.com/evan-gaertner/pyoptsparse.git
-    pip install -e pyoptsparse
 
 Run Unit Tests
 ^^^^^^^^^^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,14 +25,20 @@ In order to directly use the examples in the repository and peek at the code whe
 
 .. code-block:: bash
 
-    conda install -y cython git jsonschema make matplotlib nlopt numpy openmdao openpyxl pandas pip pyside2 pyoptsparse pytest python-benedict pyyaml ruamel_yaml scipy setuptools simpy sortedcontainers swig
+    conda install -y cython git jsonschema make matplotlib nlopt numpy openmdao openpyxl pandas pip pyside2 pytest python-benedict pyyaml ruamel_yaml scipy setuptools simpy sortedcontainers swig
     pip install marmot-agents
+
+For Linux systems:
+
+.. code-block:: bash
+
+    conda install pyoptsparse
 
 For Mac systems:
 
 .. code-block:: bash
 
-    conda install compilers
+    conda install compilers pyoptsparse
 
 For Windows systems:
 

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,6 @@ dependencies:
   - openpyxl
   - pandas
   - pip
-  - pyoptsparse
   - pyside2
   - pytest
   - pytest-cov
@@ -38,3 +37,4 @@ dependencies:
 #  - libpython # [win]
 #  - compilers # [not win]
 #  - petsc4py # [not win]
+#  - pyoptsparse # [not win]

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - openpyxl
   - pandas
   - pip
+  - pyoptsparse
   - pyside2
   - pytest
   - pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ precompExt = Extension(
 # Top-level setup
 setup(
     name="WISDEM",
-    version="3.5.0",
+    version="3.5.1",
     description="Wind-Plant Integrated System Design & Engineering Model",
     long_description="""WISDEM is a Python package for conducting multidisciplinary analysis and
     optimization of wind turbines and plants.  It is built on top of NASA's OpenMDAO library.""",


### PR DESCRIPTION
## Purpose
Update install instructions and testing environment to rely on conda version of `pyoptsparse`.  NREL users that want to use the local SNOPT will have to do their own custom install of pyoptsparse from source (working on a WISDEM-org fork).

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation