### PR TITLE
Extreme50 consistency

### DIFF
--- a/wisdem/commonse/turbine_class.py
+++ b/wisdem/commonse/turbine_class.py
@@ -27,6 +27,7 @@ class TurbineClass(om.ExplicitComponent):
         # parameters
         self.add_discrete_input("turbine_class", val="I")
         self.add_input("V_mean_overwrite", val=0.0)
+        self.add_input("V_extreme50_overwrite", val=0.0)
 
         self.add_output("V_mean", 0.0, units="m/s")
         self.add_output("V_extreme1", 0.0, units="m/s")
@@ -53,5 +54,10 @@ class TurbineClass(om.ExplicitComponent):
             outputs["V_mean"] = 0.2 * Vref
         else:
             outputs["V_mean"] = inputs["V_mean_overwrite"]
+
         outputs["V_extreme1"] = 0.8 * Vref
-        outputs["V_extreme50"] = 1.4 * Vref
+
+        if inputs["V_extreme50_overwrite"] == 0.0:
+            outputs["V_extreme50"] = 1.4 * Vref
+        else:
+            outputs["V_extreme50"] = inputs["V_extreme50_overwrite"]

--- a/wisdem/glue_code/gc_LoadInputs.py
+++ b/wisdem/glue_code/gc_LoadInputs.py
@@ -968,8 +968,8 @@ class WindTurbineOntologyPython(object):
                 Ii[12] = wt_opt["rotorse.rhoA"][i] * wt_opt["rotorse.re.y_cg"][i]
                 Ii[13] = -wt_opt["rotorse.rhoA"][i] * wt_opt["rotorse.re.x_cg"][i]
                 Ii[15] = wt_opt["rotorse.re.precomp.edge_iner"][i]
-                #Ii[16] = wt_opt["rotorse.re.precomp.edge_iner"][i]
-                Ii[18] = wt_opt['rotorse.re.precomp.flap_iner'][i]
+                # Ii[16] = wt_opt["rotorse.re.precomp.edge_iner"][i]
+                Ii[18] = wt_opt["rotorse.re.precomp.flap_iner"][i]
                 Ii[20] = wt_opt["rotorse.rhoJ"][i]
                 I.append(Ii.tolist())
             self.wt_init["components"]["blade"]["elastic_properties_mb"]["six_x_six"]["inertia_matrix"]["values"] = I
@@ -992,7 +992,6 @@ class WindTurbineOntologyPython(object):
             self.wt_init["components"]["hub"]["pitch_system_scaling_factor"] = float(
                 wt_opt["hub.pitch_system_scaling_factor"]
             )
-            self.wt_init["components"]["hub"]["spinner_gust_ws"] = float(wt_opt["hub.spinner_gust_ws"])
 
         # Update nacelle
         if self.modeling_options["flags"]["nacelle"]:
@@ -1262,8 +1261,8 @@ class WindTurbineOntologyPython(object):
 
                 s_in = wt_opt[f"floating.memgrp{idx}.s_in"].tolist()
                 yaml_out["members"][i]["outer_shape"]["outer_diameter"]["grid"] = s_in
-                d_in = wt_opt[f"floating.memgrp{idx}.outer_diameter_in"]           
-                if len(d_in)==len(s_in):
+                d_in = wt_opt[f"floating.memgrp{idx}.outer_diameter_in"]
+                if len(d_in) == len(s_in):
                     yaml_out["members"][i]["outer_shape"]["outer_diameter"]["values"] = d_in.tolist()
                 else:
                     d_in2 = d_in * np.ones(len(s_in))

--- a/wisdem/glue_code/gc_WT_DataStruc.py
+++ b/wisdem/glue_code/gc_WT_DataStruc.py
@@ -2154,7 +2154,6 @@ class Hub(om.Group):
             ivc.add_output("clearance_hub_spinner", val=0.0, units="m")
             ivc.add_output("spin_hole_incr", val=0.0)
             ivc.add_output("pitch_system_scaling_factor", val=0.54)
-            ivc.add_output("spinner_gust_ws", val=70.0, units="m/s")
             ivc.add_output("hub_in2out_circ", val=1.2)
             ivc.add_discrete_output("hub_material", val="steel")
             ivc.add_discrete_output("spinner_material", val="carbon")

--- a/wisdem/glue_code/gc_WT_InitModel.py
+++ b/wisdem/glue_code/gc_WT_InitModel.py
@@ -656,7 +656,6 @@ def assign_hub_values(wt_opt, hub, flags):
         wt_opt["hub.clearance_hub_spinner"] = hub["clearance_hub_spinner"]
         wt_opt["hub.spin_hole_incr"] = hub["spin_hole_incr"]
         wt_opt["hub.pitch_system_scaling_factor"] = hub["pitch_system_scaling_factor"]
-        wt_opt["hub.spinner_gust_ws"] = hub["spinner_gust_ws"]
         wt_opt["hub.hub_material"] = hub["hub_material"]
         wt_opt["hub.spinner_material"] = hub["spinner_material"]
 
@@ -690,7 +689,9 @@ def assign_nacelle_values(wt_opt, modeling_options, nacelle, flags):
 
         if modeling_options["WISDEM"]["DriveSE"]["direct"]:
             if wt_opt["nacelle.gear_ratio"] > 1:
-                raise Exception('The gear ratio is larger than 1, but the wind turbine is marked as direct drive. Please check the input yaml file.')
+                raise Exception(
+                    "The gear ratio is larger than 1, but the wind turbine is marked as direct drive. Please check the input yaml file."
+                )
             # Direct only
             wt_opt["nacelle.nose_wall_thickness"] = nacelle["drivetrain"]["nose_wall_thickness"]
             wt_opt["nacelle.nose_diameter"] = nacelle["drivetrain"]["nose_diameter"]
@@ -701,7 +702,9 @@ def assign_nacelle_values(wt_opt, modeling_options, nacelle, flags):
             wt_opt["nacelle.bedplate_wall_thickness"] = np.interp(s_bedplate, s_bed_thick_in, v_bed_thick_in)
         else:
             if wt_opt["nacelle.gear_ratio"] == 1:
-                raise Exception('The gear ratio is set to 1, but the wind turbine is marked as geared. Please check the input yaml file.')
+                raise Exception(
+                    "The gear ratio is set to 1, but the wind turbine is marked as geared. Please check the input yaml file."
+                )
             # Geared only
             wt_opt["nacelle.hss_wall_thickness"] = nacelle["drivetrain"]["hss_wall_thickness"]
             wt_opt["nacelle.hss_diameter"] = nacelle["drivetrain"]["hss_diameter"]

--- a/wisdem/glue_code/glue_code.py
+++ b/wisdem/glue_code/glue_code.py
@@ -286,7 +286,7 @@ class WT_RNTA(om.Group):
             self.connect("hub.clearance_hub_spinner", "drivese.clearance_hub_spinner")
             self.connect("hub.spin_hole_incr", "drivese.spin_hole_incr")
             self.connect("hub.pitch_system_scaling_factor", "drivese.pitch_system_scaling_factor")
-            self.connect("hub.spinner_gust_ws", "drivese.spinner_gust_ws")
+            self.connect("rotorse.wt_class.V_extreme50", "drivese.spinner_gust_ws")
 
             self.connect("configuration.n_blades", "drivese.n_blades")
 
@@ -922,6 +922,7 @@ class WindPark(om.Group):
                 self.connect("configuration.n_blades", "landbosse.number_of_blades")
                 if modeling_options["flags"]["blade"]:
                     self.connect("rotorse.rp.powercurve.rated_T", "landbosse.rated_thrust_N")
+                    self.connect("rotorse.wt_class.V_extreme50", "landbosse.gust_velocity_m_per_s")
                 self.connect("towerse.tower_mass", "landbosse.tower_mass")
                 if modeling_options["flags"]["nacelle"]:
                     self.connect("drivese.nacelle_mass", "landbosse.nacelle_mass")

--- a/wisdem/inputs/modeling_schema.yaml
+++ b/wisdem/inputs/modeling_schema.yaml
@@ -130,7 +130,7 @@ properties:
                         type: number
                         description: Number of standard deviations for strength of gust
                         minimum: 0.0
-                        maximum: 5.0
+                        maximum: 15.0
                         default: 3.0
                         unit: none
                     root_fastener_s_f:

--- a/wisdem/test/test_gluecode/test_gluecode.py
+++ b/wisdem/test/test_gluecode/test_gluecode.py
@@ -25,7 +25,7 @@ class TestRegression(unittest.TestCase):
 
         self.assertAlmostEqual(wt_opt["rotorse.re.precomp.blade_mass"][0], 16403.682326940743, 2)
         self.assertAlmostEqual(wt_opt["rotorse.rp.AEP"][0] * 1.0e-6, 23.8785992698, 2)
-        self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 51.894854418723824, 2)
+        self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 51.931806039357404, 1)
         self.assertAlmostEqual(wt_opt["rotorse.rs.tip_pos.tip_deflection"][0], 4.6449973294, 1)
         self.assertAlmostEqual(wt_opt["towerse.z_param"][-1], 87.7, 2)
 


### PR DESCRIPTION
## Purpose
Make the value and definition of the 50-year extreme gust the same across the few modules that were previously using independent values.  User can also now override the vallue.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation