### PR TITLE
Feature nopt/nspan mismatch error

### DIFF
--- a/wisdem/glue_code/gc_LoadInputs.py
+++ b/wisdem/glue_code/gc_LoadInputs.py
@@ -649,21 +649,29 @@ class WindTurbineOntologyPython(object):
             and not blade_opt_options["aero_shape"]["twist"]["inverse"]
         ):
             blade_opt_options["aero_shape"]["twist"]["n_opt"] = self.modeling_options["WISDEM"]["RotorSE"]["n_span"]
+        elif blade_opt_options["aero_shape"]["twist"]["n_opt"] > self.modeling_options["WISDEM"]["RotorSE"]["n_span"]:
+            raise ValueError("you are attempting to do an analysis using fewer analysis points than control points.")
         elif blade_opt_options["aero_shape"]["twist"]["n_opt"] < 4:
             raise ValueError("Cannot optimize twist with less than 4 control points along blade span")
 
         if not blade_opt_options["aero_shape"]["chord"]["flag"]:
             blade_opt_options["aero_shape"]["chord"]["n_opt"] = self.modeling_options["WISDEM"]["RotorSE"]["n_span"]
+        elif blade_opt_options["aero_shape"]["chord"]["n_opt"] > self.modeling_options["WISDEM"]["RotorSE"]["n_span"]:
+            raise ValueError("you are attempting to do an analysis using fewer analysis points than control points.")
         elif blade_opt_options["aero_shape"]["chord"]["n_opt"] < 4:
             raise ValueError("Cannot optimize chord with less than 4 control points along blade span")
 
         if not blade_opt_options["aero_shape"]["t/c"]["flag"]:
             blade_opt_options["aero_shape"]["t/c"]["n_opt"] = self.modeling_options["WISDEM"]["RotorSE"]["n_span"]
+        elif blade_opt_options["aero_shape"]["t/c"]["n_opt"] > self.modeling_options["WISDEM"]["RotorSE"]["n_span"]:
+            raise ValueError("you are attempting to do an analysis using fewer analysis points than control points.")
         elif blade_opt_options["aero_shape"]["t/c"]["n_opt"] < 4:
             raise ValueError("Cannot optimize t/c with less than 4 control points along blade span")
 
         if not blade_opt_options["aero_shape"]["L/D"]["flag"]:
             blade_opt_options["aero_shape"]["L/D"]["n_opt"] = self.modeling_options["WISDEM"]["RotorSE"]["n_span"]
+        elif blade_opt_options["aero_shape"]["L/D"]["n_opt"] > self.modeling_options["WISDEM"]["RotorSE"]["n_span"]:
+            raise ValueError("you are attempting to do an analysis using fewer analysis points than control points.")
         elif blade_opt_options["aero_shape"]["L/D"]["n_opt"] < 4:
             raise ValueError("Cannot optimize L/D with less than 4 control points along blade span")
 
@@ -671,6 +679,8 @@ class WindTurbineOntologyPython(object):
             blade_opt_options["structure"]["spar_cap_ss"]["n_opt"] = self.modeling_options["WISDEM"]["RotorSE"][
                 "n_span"
             ]
+        elif blade_opt_options["structure"]["spar_cap_ss"]["n_opt"] > self.modeling_options["WISDEM"]["RotorSE"]["n_span"]:
+            raise ValueError("you are attempting to do an analysis using fewer analysis points than control points.")
         elif blade_opt_options["structure"]["spar_cap_ss"]["n_opt"] < 4:
             raise ValueError("Cannot optimize spar cap suction side with less than 4 control points along blade span")
 
@@ -678,11 +688,15 @@ class WindTurbineOntologyPython(object):
             blade_opt_options["structure"]["spar_cap_ps"]["n_opt"] = self.modeling_options["WISDEM"]["RotorSE"][
                 "n_span"
             ]
+        elif blade_opt_options["structure"]["spar_cap_ps"]["n_opt"] > self.modeling_options["WISDEM"]["RotorSE"]["n_span"]:
+            raise ValueError("you are attempting to do an analysis using fewer analysis points than control points.")
         elif blade_opt_options["structure"]["spar_cap_ps"]["n_opt"] < 4:
             raise ValueError("Cannot optimize spar cap pressure side with less than 4 control points along blade span")
 
         if not blade_opt_options["structure"]["te_ss"]["flag"]:
             blade_opt_options["structure"]["te_ss"]["n_opt"] = self.modeling_options["WISDEM"]["RotorSE"]["n_span"]
+        elif blade_opt_options["structure"]["te_ss"]["n_opt"] > self.modeling_options["WISDEM"]["RotorSE"]["n_span"]:
+            raise ValueError("you are attempting to do an analysis using fewer analysis points than control points.")
         elif blade_opt_options["structure"]["te_ss"]["n_opt"] < 4:
             raise ValueError(
                 "Cannot optimize trailing edge suction side with less than 4 control points along blade span"
@@ -690,6 +704,8 @@ class WindTurbineOntologyPython(object):
 
         if not blade_opt_options["structure"]["te_ps"]["flag"]:
             blade_opt_options["structure"]["te_ps"]["n_opt"] = self.modeling_options["WISDEM"]["RotorSE"]["n_span"]
+        elif blade_opt_options["structure"]["te_ps"]["n_opt"] > self.modeling_options["WISDEM"]["RotorSE"]["n_span"]:
+            raise ValueError("you are attempting to do an analysis using fewer analysis points than control points.")
         elif blade_opt_options["structure"]["te_ps"]["n_opt"] < 4:
             raise ValueError(
                 "Cannot optimize trailing edge pressure side with less than 4 control points along blade span"

--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -1089,6 +1089,7 @@ class PoseOptimization(object):
 
         # Set non-linear blade constraints
         blade_constr = self.opt["constraints"]["blade"]
+
         if blade_constr["strains_spar_cap_ss"]["flag"]:
             if blade_opt["structure"]["spar_cap_ss"]["flag"]:
                 if blade_constr["strains_spar_cap_ss"]["index_end"] > blade_opt["structure"]["spar_cap_ss"]["n_opt"]:
@@ -1262,6 +1263,15 @@ class PoseOptimization(object):
             wt_opt.model.add_constraint(
                 "rotorse.rp.AEP", lower=self.opt["constraints"]["blade"]["AEP"]["min"], ref=-1.0e6
             )
+
+        # to constrain C_T and forcibly design higher thrust turbines
+        if blade_constr["thrust_coeff"]["flag"]:
+            if 'lower' in blade_constr["thrust_coeff"]:
+                wt_opt.model.add_constraint("rotorse.rp.powercurve.Ct_regII", lower= blade_constr["thrust_coeff"]["lower"])
+            elif 'upper' in blade_constr["thrust_coeff"]:
+                wt_opt.model.add_constraint("rotorse.rp.powercurve.Ct_regII", upper= blade_constr["thrust_coeff"]["upper"])
+            else:
+                raise Exception("thrust coefficient constraint requested but now upper or lower constraint found.")
 
         # Tower contraints
         tower_constr = self.opt["constraints"]["tower"]

--- a/wisdem/inputs/analysis_schema.yaml
+++ b/wisdem/inputs/analysis_schema.yaml
@@ -1065,6 +1065,18 @@ properties:
                                 units: kWh
                                 default: 1.0
                                 minimum: 1.0
+                    thrust_coeff:
+                        type: object
+                        description: (EXPERIMENTAL) Bound the ccblade thrust coefficient away from unconstrained optimal when optimizing for power, for highly-loaded rotors
+                        default: {}
+                        properties:
+                            flag: *flag
+                            lower:
+                                type: number
+                                minimum: 0.0
+                            upper:
+                                type: number
+                                minimum: 0.0
             tower: &towcon
                 type: object
                 default: {}

--- a/wisdem/rotorse/rotor_power.py
+++ b/wisdem/rotorse/rotor_power.py
@@ -276,6 +276,7 @@ class ComputePowerCurve(ExplicitComponent):
             desc="Lift over drag distribution along blade span at cut-in wind speed",
         )
         self.add_output("Cp_regII", val=0.0, desc="power coefficient at cut-in wind speed")
+        self.add_output("Ct_regII", val=0.0, desc="thrust coefficient at cut-in wind speed")
         self.add_output(
             "cl_regII", val=np.zeros(n_span), desc="lift coefficient distribution along blade span at cut-in wind speed"
         )
@@ -812,6 +813,7 @@ class ComputePowerCurve(ExplicitComponent):
         outputs["cd_regII"] = loads["Cd"]
         outputs["L_D"] = loads["Cl"] / loads["Cd"]
         outputs["Cp_regII"] = Cp_aero[id_regII]
+        outputs["Ct_regII"] = Ct_aero[id_regII]
 
 
 class ComputeSplines(ExplicitComponent):


### PR DESCRIPTION

## Purpose
It's currently possible to run an optimization w/ finer control point distribution (`n_opt`, distributed uniformly) than the analysis nodes (`n_span`, distributed uniformly). The resulting yaml files have the analysis nodes, and information loss/ambiguity w.r.t. the control points will occur. This prevents that from occuring by raising an error if `n_opt` > `n_span`.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Testing

Tested against cases that use relevant features.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
