### PR TITLE
Monopile and Other various improvements

### DIFF
--- a/.github/workflows/Publish_WISDEM.yml
+++ b/.github/workflows/Publish_WISDEM.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Setup GNU Fortran
-        uses: modflowpy/install-gfortran-action@v1
+        uses: awvwgk/setup-fortran@main
               
       - name: Checkout
         uses: actions/checkout@v3

--- a/examples/05_tower_monopile/analysis_options_monopile.yaml
+++ b/examples/05_tower_monopile/analysis_options_monopile.yaml
@@ -37,16 +37,16 @@ constraints:
         shell_buckling:
             flag: True
         d_to_t:
-            flag: True
+            flag: False
             lower_bound: 120.0
             upper_bound: 2000.0
         taper:
-            flag: True
+            flag: False
             lower_bound: 0.2
         slope:
             flag: True
         frequency_1:
-            flag: True
+            flag: False
             lower_bound: 0.13
             upper_bound: 0.40
     monopile:
@@ -57,18 +57,20 @@ constraints:
         shell_buckling:
             flag: True
         d_to_t:
-            flag: True
+            flag: False
             lower_bound: 120.0
             upper_bound: 2000.0
         taper:
-            flag: True
+            flag: False
             lower_bound: 0.2
         slope:
+            flag: True
+        thickness_slope:
             flag: True
         frequency_1:
             flag: True
             lower_bound: 0.13
-            upper_bound: 0.40
+            upper_bound: 0.20
         pile_depth:
             flag: True
             lower_bound: 0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "numpy", "ninja", "meson>=0.60.0", "wheel"]
+requires = ["setuptools", "numpy", "ninja", "meson>=1.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -33,7 +33,6 @@ classifiers = [  # Optional
   # that you indicate you support Python 3. These classifiers are *not*
   # checked by "pip install". See instead "python_requires" below.
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -52,7 +51,6 @@ dependencies = [
   "openpyxl",
   "pandas",
   "pydoe2",
-  "pyoptsparse",
   "python-benedict",
   "pyyaml",
   "ruamel.yaml",
@@ -74,6 +72,7 @@ dependencies = [
 dev = ["meson", "ninja", "swig"]
 test = ["coveralls", "pytest", "pytest-cov"]
 docs = ["sphinx", "sphinxcontrib-bibtex", "sphinx_rtd_theme"]
+opt = ["pyoptsparse"]
 
 # List URLs that are relevant to your project
 #

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,10 @@ import re
 import shutil
 import platform
 import subprocess
-
 import setuptools
+
+#######
+# This forces wheels to be platform specific
 from setuptools.dist import Distribution
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
@@ -22,6 +24,7 @@ class BinaryDistribution(Distribution):
     """Distribution which always forces a binary package with platform name"""
     def has_ext_modules(foo):
         return True
+#######
     
 def run_meson_build(staging_dir):
     prefix = os.path.join(os.getcwd(), staging_dir)

--- a/wisdem/commonse/cylinder_member.py
+++ b/wisdem/commonse/cylinder_member.py
@@ -2123,12 +2123,11 @@ class CylinderPostFrame(om.ExplicitComponent):
     def initialize(self):
         self.options.declare("modeling_options")
         self.options.declare("n_dlc")
+        self.options.declare("n_full")
 
     def setup(self):
-        n_height = self.options["modeling_options"]["n_height"]
-        n_refine = self.options["modeling_options"]["n_refine"]
-        n_full = get_nfull(n_height, nref=n_refine)
         n_dlc = self.options["n_dlc"]
+        n_full = self.options["n_full"]
 
         # effective geometry -- used for handbook methods to estimate hoop stress, buckling, fatigue
         self.add_input("z_full", np.zeros(n_full), units="m")

--- a/wisdem/drivetrainse/drive_structure.py
+++ b/wisdem/drivetrainse/drive_structure.py
@@ -1032,7 +1032,7 @@ class Nose_Stator_Bedplate_Frame(om.ExplicitComponent):
         outputs["constr_mb1_defl"] = np.abs(outputs["mb1_angle"] / inputs["mb1_max_defl_ang"])
         outputs["constr_mb2_defl"] = np.abs(outputs["mb2_angle"] / inputs["mb2_max_defl_ang"])
         outputs["stator_deflection"] = stator_deflection.max()
-        outputs["stator_angle"] = stator_angle.max()
+        outputs["stator_angle"] = np.abs(stator_angle).max()
         outputs["constr_stator_deflection"] = gamma * outputs["stator_deflection"] / stator_defl_allow
         outputs["constr_stator_angle"] = gamma * outputs["stator_angle"] / stator_angle_allow
 

--- a/wisdem/fixed_bottomse/monopile.py
+++ b/wisdem/fixed_bottomse/monopile.py
@@ -546,7 +546,7 @@ class MonopileFrame(om.ExplicitComponent):
 
         # Note, need len()-1 because Frame3DD crashes if mass add at end
         if tower_flag:
-            midx = np.array([n, n_mono, 1], dtype=np.int_)
+            midx = np.array([n-1, n_mono, 1], dtype=np.int_)
             m_add = np.r_[m_rna, m_trans, m_grav]
             mI = np.c_[I_rna, I_trans, I_grav]
             mrho = np.c_[cg_rna, np.zeros(3), np.zeros(3)]
@@ -574,7 +574,7 @@ class MonopileFrame(om.ExplicitComponent):
 
         # ------------------------------------
         # Debugging
-        # self.frame.write('monopile_debug.3dd')
+        self.frame.write('monopile_debug.3dd')
         # -----------------------------------
         # run the analysis
         displacements, forces, rxns, internalForces, mass, modal = self.frame.run()

--- a/wisdem/fixed_bottomse/monopile.py
+++ b/wisdem/fixed_bottomse/monopile.py
@@ -285,6 +285,11 @@ class MonopileFrame(om.ExplicitComponent):
         self.add_input("section_E", np.zeros(n_full - 1), units="Pa")
         self.add_input("section_G", np.zeros(n_full - 1), units="Pa")
         self.add_output("section_L", np.zeros(n_full - 1 + ntow_sec), units="m")
+        self.add_input("d_full", np.zeros(n_full), units="m")
+        self.add_input("t_full", np.zeros(n_full - 1), units="m")
+        self.add_input("sigma_y_full", np.zeros(n_full -1), units="Pa")
+        self.add_input("qdyn", np.zeros((n_full,nLC)), units="Pa")
+        self.add_input("bending_height", 0.0, units="m")
 
         # cross-sectional data along tower
         self.add_input("tower_xyz", np.zeros((n_full_tow, 3)), units="m")
@@ -297,6 +302,11 @@ class MonopileFrame(om.ExplicitComponent):
         self.add_input("tower_rho", np.zeros(ntow_sec), units="kg/m**3")
         self.add_input("tower_E", np.zeros(ntow_sec), units="Pa")
         self.add_input("tower_G", np.zeros(ntow_sec), units="Pa")
+        self.add_input("tower_d_full", np.zeros(n_full_tow), units="m")
+        self.add_input("tower_t_full", np.zeros(ntow_sec), units="m")
+        self.add_input("tower_sigma_y_full", np.zeros(ntow_sec), units="Pa")
+        self.add_input("tower_qdyn", np.zeros((n_full_tow,nLC)), units="Pa")
+        self.add_input("tower_bending_height", 0.0, units="m")
 
         # point loads
         self.add_input("rna_F", np.zeros((3, nLC)), units="N")
@@ -353,6 +363,24 @@ class MonopileFrame(om.ExplicitComponent):
         self.add_output("monopile_Mzz", val=np.zeros((n_full - 1, nLC)), units="N*m")
         self.add_output("mudline_F", val=np.zeros((3, nLC)), units="N")
         self.add_output("mudline_M", val=np.zeros((3, nLC)), units="N*m")
+
+
+        # Tower and monopile combined
+        self.add_output("monopile_tower_z_full", val=np.zeros(n_full + n_full_tow - 1), units="m")
+        self.add_output("monopile_tower_d_full", val=np.zeros(n_full + n_full_tow - 1), units="m")
+        self.add_output("monopile_tower_t_full", val=np.zeros(n_full + ntow_sec - 1), units="m")
+        self.add_output("monopile_tower_rho_full", val=np.zeros(n_full + ntow_sec -1), units="kg/m**3")
+        self.add_output("monopile_tower_E_full", val=np.zeros(n_full + ntow_sec -1), units="Pa")
+        self.add_output("monopile_tower_G_full", val=np.zeros(n_full + ntow_sec -1), units="Pa")
+        self.add_output("monopile_tower_sigma_y_full", val=np.zeros(n_full + ntow_sec -1), units="Pa")
+        self.add_output("monopile_tower_bending_height", val=0.0, units="m")
+        self.add_output("monopile_tower_qdyn", val=np.zeros((n_full + n_full_tow - 1, nLC)), units="Pa")
+        self.add_output("monopile_tower_Fz", val=np.zeros((n_full + ntow_sec -1, nLC)), units="N")
+        self.add_output("monopile_tower_Vx", val=np.zeros((n_full + ntow_sec -1, nLC)), units="N")
+        self.add_output("monopile_tower_Vy", val=np.zeros((n_full + ntow_sec -1, nLC)), units="N")
+        self.add_output("monopile_tower_Mxx", val=np.zeros((n_full + ntow_sec -1, nLC)), units="N*m")
+        self.add_output("monopile_tower_Myy", val=np.zeros((n_full + ntow_sec -1, nLC)), units="N*m")
+        self.add_output("monopile_tower_Mzz", val=np.zeros((n_full + ntow_sec -1, nLC)), units="N*m")
 
     def compute(self, inputs, outputs):
         frame3dd_opt = self.options["frame3dd_opt"]
@@ -437,6 +465,23 @@ class MonopileFrame(om.ExplicitComponent):
             E = np.r_[inputs["section_E"], inputs["tower_E"]]
             G = np.r_[inputs["section_G"], inputs["tower_G"]]
             rho = np.r_[inputs["section_rho"], inputs["tower_rho"]]
+            d = np.r_[inputs["d_full"][:-1], inputs["tower_d_full"]]
+            t = np.r_[inputs["t_full"], inputs["tower_t_full"]]
+            sigma_y = np.r_[inputs["sigma_y_full"], inputs["tower_sigma_y_full"]]
+
+            outputs["monopile_tower_z_full"] = z
+            outputs["monopile_tower_d_full"] = d
+            outputs["monopile_tower_t_full"] = t
+            outputs["monopile_tower_rho_full"] = rho
+            outputs["monopile_tower_E_full"] = E
+            outputs["monopile_tower_G_full"] = G
+            outputs["monopile_tower_sigma_y_full"] = sigma_y
+            outputs["monopile_tower_bending_height"] = inputs['bending_height'] + inputs['tower_bending_height']
+            for ic in range(nLC):
+                qdyn = np.r_[inputs["qdyn"][:-1,ic], inputs["tower_qdyn"][:,ic]]
+                outputs["monopile_tower_qdyn"][:, ic] = qdyn
+
+
         else:
             Area = inputs["section_A"]
             Asx = inputs["section_Asx"]
@@ -574,7 +619,7 @@ class MonopileFrame(om.ExplicitComponent):
 
         # ------------------------------------
         # Debugging
-        self.frame.write('monopile_debug.3dd')
+        # self.frame.write('monopile_debug.3dd')
         # -----------------------------------
         # run the analysis
         displacements, forces, rxns, internalForces, mass, modal = self.frame.run()
@@ -650,6 +695,14 @@ class MonopileFrame(om.ExplicitComponent):
         outputs["monopile_Mxx"] = Mxx[: (n_mono - 1)]
         outputs["monopile_Myy"] = Myy[: (n_mono - 1)]
         outputs["monopile_Mzz"] = Mzz[: (n_mono - 1)]
+    
+
+        outputs["monopile_tower_Fz"] = Fz
+        outputs["monopile_tower_Vx"] = Vx
+        outputs["monopile_tower_Vy"] = Vy
+        outputs["monopile_tower_Mxx"] = Mxx
+        outputs["monopile_tower_Myy"] = Myy
+        outputs["monopile_tower_Mzz"] = Mzz
 
 
 class MonopileSE(om.Group):
@@ -778,13 +831,10 @@ class MonopileSE(om.Group):
         self.add_subsystem("loads", mem.MemberLoads(n_full=n_full, n_lc=nLC, wind=wind, hydro=True), promotes=["*"])
 
         n_full_tow = 0
-        try:
-            if self.options["modeling_options"]["flags"]["tower"]:
-                tow_opt = self.options["modeling_options"]["WISDEM"]["TowerSE"]
-                n_height = tow_opt["n_height"]
-                n_full_tow = mem.get_nfull(n_height, nref=tow_opt["n_refine"])
-        except:
-            pass
+        if self.options["modeling_options"]["flags"]["tower"]:
+            tow_opt = self.options["modeling_options"]["WISDEM"]["TowerSE"]
+            n_height = tow_opt["n_height"]
+            n_full_tow = mem.get_nfull(n_height, nref=tow_opt["n_refine"])
 
         self.add_subsystem(
             "monopile",
@@ -808,6 +858,16 @@ class MonopileSE(om.Group):
                 "section_rho",
                 "section_E",
                 "section_G",
+                "d_full",
+                "t_full",
+                "sigma_y_full",
+                "tower_d_full",
+                "tower_t_full",
+                "tower_sigma_y_full",
+                "bending_height",
+                "tower_bending_height",
+                "qdyn",
+                "tower_qdyn",
                 "tower_A",
                 "tower_Asx",
                 "tower_Asy",
@@ -853,9 +913,10 @@ class MonopileSE(om.Group):
             ],
         )
 
+        # Compute stress and buckling constraints for monopile alone
         self.add_subsystem(
             "post",
-            mem.CylinderPostFrame(modeling_options=mod_opt, n_dlc=nLC),
+            mem.CylinderPostFrame(modeling_options=mod_opt, n_dlc=nLC, n_full = n_full),
             promotes=[
                 "z_full",
                 "d_full",
@@ -879,3 +940,26 @@ class MonopileSE(om.Group):
         self.connect("monopile.monopile_Mxx", "post.cylinder_Mxx")
         self.connect("monopile.monopile_Myy", "post.cylinder_Myy")
         self.connect("monopile.monopile_Mzz", "post.cylinder_Mzz")
+
+        if self.options["modeling_options"]["flags"]["tower"]:
+            # Compute stress and buckling constraints for monopile and tower combined
+            self.add_subsystem(
+                "post_monopile_tower",
+                mem.CylinderPostFrame(modeling_options=mod_opt, n_dlc=nLC, n_full = n_full + n_full_tow - 1),
+            )
+
+            self.connect("monopile.monopile_tower_z_full", "post_monopile_tower.z_full")
+            self.connect("monopile.monopile_tower_d_full", "post_monopile_tower.d_full")
+            self.connect("monopile.monopile_tower_t_full", "post_monopile_tower.t_full")
+            self.connect("monopile.monopile_tower_rho_full", "post_monopile_tower.rho_full")
+            self.connect("monopile.monopile_tower_E_full", "post_monopile_tower.E_full")
+            self.connect("monopile.monopile_tower_G_full", "post_monopile_tower.G_full")
+            self.connect("monopile.monopile_tower_sigma_y_full", "post_monopile_tower.sigma_y_full")
+            self.connect("monopile.monopile_tower_bending_height", "post_monopile_tower.bending_height")
+            self.connect("monopile.monopile_tower_qdyn", "post_monopile_tower.qdyn")
+            self.connect("monopile.monopile_tower_Fz", "post_monopile_tower.cylinder_Fz")
+            self.connect("monopile.monopile_tower_Vx", "post_monopile_tower.cylinder_Vx")
+            self.connect("monopile.monopile_tower_Vy", "post_monopile_tower.cylinder_Vy")
+            self.connect("monopile.monopile_tower_Mxx", "post_monopile_tower.cylinder_Mxx")
+            self.connect("monopile.monopile_tower_Myy", "post_monopile_tower.cylinder_Myy")
+            self.connect("monopile.monopile_tower_Mzz", "post_monopile_tower.cylinder_Mzz")

--- a/wisdem/fixed_bottomse/monopile.py
+++ b/wisdem/fixed_bottomse/monopile.py
@@ -527,7 +527,7 @@ class MonopileFrame(om.ExplicitComponent):
                 rna_F = inputs["rna_F"][:, k]
                 rna_M = inputs["rna_M"][:, k]
                 load.changePointLoads(
-                    np.array([n], dtype=np.int_),  # -1 b/c same reason as above
+                    np.array([n-1], dtype=np.int_),  # -1 b/c same reason as above
                     np.array([rna_F[0]]).flatten(),
                     np.array([rna_F[1]]).flatten(),
                     np.array([rna_F[2]]).flatten(),
@@ -545,7 +545,7 @@ class MonopileFrame(om.ExplicitComponent):
                 turb_F = inputs["turbine_F"][:, k]
                 turb_M = inputs["turbine_M"][:, k]
                 load.changePointLoads(
-                    np.array([n], dtype=np.int_),  # -1 b/c same reason as above
+                    np.array([n-1], dtype=np.int_),  # -1 b/c same reason as above
                     np.array([turb_F[0]]).flatten(),
                     np.array([turb_F[1]]).flatten(),
                     np.array([turb_F[2]]).flatten(),

--- a/wisdem/fixed_bottomse/monopile.py
+++ b/wisdem/fixed_bottomse/monopile.py
@@ -849,6 +849,7 @@ class MonopileSE(om.Group):
                 "tower_torsion_modes",
                 "f1",
                 "f2",
+                "water_depth"
             ],
         )
 

--- a/wisdem/fixed_bottomse/monopile.py
+++ b/wisdem/fixed_bottomse/monopile.py
@@ -728,7 +728,7 @@ class MonopileSE(om.Group):
             ("wall_thickness", "monopile_wall_thickness"),
         ]
         if n_height > 2:
-            promlist + ["thickness_slope"]
+            promlist += ["thickness_slope"]
 
         temp_opt = mod_opt.copy()
         temp_opt["n_height"] = [n_height]

--- a/wisdem/glue_code/gc_LoadInputs.py
+++ b/wisdem/glue_code/gc_LoadInputs.py
@@ -1081,6 +1081,9 @@ class WindTurbineOntologyPython(object):
             self.wt_init["components"]["hub"]["pitch_system_scaling_factor"] = float(
                 wt_opt["hub.pitch_system_scaling_factor"]
             )
+            self.wt_init["components"]["hub"]["elastic_properties_mb"]['system_mass'] = float(wt_opt["drivese.hub_system_mass"])
+            self.wt_init["components"]["hub"]["elastic_properties_mb"]['system_inertia'] = wt_opt["drivese.hub_system_I"].tolist()
+            # self.wt_init["components"]["hub"]["elastic_properties_mb"]['system_center_mass'] = wt_opt["drivese.hub_system_cm"].tolist()
 
         # Update nacelle
         if self.modeling_options["flags"]["nacelle"]:
@@ -1130,6 +1133,11 @@ class WindTurbineOntologyPython(object):
             self.wt_init["components"]["nacelle"]["drivetrain"]["bedplate_material"] = wt_opt[
                 "nacelle.bedplate_material"
             ]
+            self.wt_init["components"]["nacelle"]["elastic_properties_mb"]["system_mass"] = float(wt_opt["drivese.above_yaw_mass"])
+            self.wt_init["components"]["nacelle"]["elastic_properties_mb"]["yaw_mass"] = float(wt_opt["drivese.yaw_mass"])
+            self.wt_init["components"]["nacelle"]["elastic_properties_mb"]["system_inertia"] = wt_opt["drivese.above_yaw_I"].tolist()
+            self.wt_init["components"]["nacelle"]["elastic_properties_mb"]["system_inertia_tt"] = wt_opt["drivese.above_yaw_I_TT"].tolist()
+            self.wt_init["components"]["nacelle"]["elastic_properties_mb"]["system_center_mass"] = wt_opt["drivese.above_yaw_cm"].tolist()
 
             if self.modeling_options["WISDEM"]["DriveSE"]["direct"]:
                 # Direct only

--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -1293,8 +1293,10 @@ class PoseOptimization(object):
             else:
                 raise Exception("thrust coefficient constraint requested but now upper or lower constraint found.")
 
-        # Tower contraints
+        # Tower and monopile contraints
         tower_constr = self.opt["constraints"]["tower"]
+        monopile_constr = self.opt["constraints"]["monopile"]
+        
         if tower_constr["height_constraint"]["flag"]:
             wt_opt.model.add_constraint(
                 "towerse.height_constraint",
@@ -1302,13 +1304,13 @@ class PoseOptimization(object):
                 upper=tower_constr["height_constraint"]["upper_bound"],
             )
 
-        if tower_constr["stress"]["flag"]:
+        if tower_constr["stress"]["flag"] and not monopile_constr["stress"]["flag"]:
             wt_opt.model.add_constraint("towerse.post.constr_stress", upper=1.0)
 
-        if tower_constr["global_buckling"]["flag"]:
+        if tower_constr["global_buckling"]["flag"] and not monopile_constr["global_buckling"]["flag"]:
             wt_opt.model.add_constraint("towerse.post.constr_global_buckling", upper=1.0)
 
-        if tower_constr["shell_buckling"]["flag"]:
+        if tower_constr["shell_buckling"]["flag"] and not monopile_constr["shell_buckling"]["flag"]:
             wt_opt.model.add_constraint("towerse.post.constr_shell_buckling", upper=1.0)
 
         if tower_constr["d_to_t"]["flag"]:
@@ -1345,16 +1347,19 @@ class PoseOptimization(object):
                 upper=tower_constr["frequency_1"]["upper_bound"],
             )
 
-        # Monopile constraints
-        monopile_constr = self.opt["constraints"]["monopile"]
-
-        if monopile_constr["stress"]["flag"]:
+        if monopile_constr["stress"]["flag"] and tower_constr["stress"]["flag"]:
+            wt_opt.model.add_constraint("fixedse.post_monopile_tower.constr_stress", upper=1.0)
+        elif monopile_constr["stress"]["flag"]:
             wt_opt.model.add_constraint("fixedse.post.constr_stress", upper=1.0)
 
-        if monopile_constr["global_buckling"]["flag"]:
+        if monopile_constr["global_buckling"]["flag"] and tower_constr["global_buckling"]["flag"]:
+            wt_opt.model.add_constraint("fixedse.post_monopile_tower.constr_global_buckling", upper=1.0)
+        elif monopile_constr["global_buckling"]["flag"]:
             wt_opt.model.add_constraint("fixedse.post.constr_global_buckling", upper=1.0)
 
-        if monopile_constr["shell_buckling"]["flag"]:
+        if monopile_constr["shell_buckling"]["flag"] and tower_constr["shell_buckling"]["flag"]:
+            wt_opt.model.add_constraint("fixedse.post_monopile_tower.constr_shell_buckling", upper=1.0)
+        elif monopile_constr["shell_buckling"]["flag"]:
             wt_opt.model.add_constraint("fixedse.post.constr_shell_buckling", upper=1.0)
 
         if monopile_constr["d_to_t"]["flag"]:

--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -1599,6 +1599,7 @@ class PoseOptimization(object):
                 layer_name = self.modeling["WISDEM"]["RotorSE"]["layer_name"]
                 n_layers = self.modeling["WISDEM"]["RotorSE"]["n_layers"]
                 ss_before_ps = False
+                spar_cap_ps_found = False
                 for i in range(n_layers):
                     if layer_name[i].lower() == spar_cap_ss_name:
                         spar_cap_ss_interpolator = PchipInterpolator(
@@ -1615,6 +1616,7 @@ class PoseOptimization(object):
                                 init_spar_cap_ss_opt[j] = 0.
                         ss_before_ps = True
                     elif layer_name[i].lower() == spar_cap_ps_name:
+                        spar_cap_ps_found = True
                         if (
                             self.opt["design_variables"]["blade"]["structure"]["spar_cap_ps"]["equal_to_suction"]
                             == False
@@ -1633,7 +1635,7 @@ class PoseOptimization(object):
                                     init_spar_cap_ps_opt[j] = 0.
                         else:
                             init_spar_cap_ps_opt = init_spar_cap_ss_opt
-                if not ss_before_ps:
+                if not ss_before_ps or not spar_cap_ps_found:
                     raise Exception(
                         "Please set the spar cap names for suction and pressure sides among the RotorSE modeling options"
                     )

--- a/wisdem/glue_code/glue_code.py
+++ b/wisdem/glue_code/glue_code.py
@@ -548,6 +548,12 @@ class WT_RNTA(om.Group):
             self.connect("monopile.gravity_foundation_mass", "fixedse.gravity_foundation_mass")
             if modeling_options["flags"]["tower"]:
                 self.connect("towerse.nodes_xyz", "fixedse.tower_xyz")
+                self.connect("towerse.d_full", "fixedse.tower_d_full")
+                self.connect("towerse.t_full", "fixedse.tower_t_full")
+                self.connect("towerse.sigma_y_full", "fixedse.tower_sigma_y_full")
+                self.connect("towerse.qdyn", "fixedse.tower_qdyn")
+                self.connect("tower_grid.height", "fixedse.tower_bending_height")
+
                 for var in ["A", "Asx", "Asy", "Ixx", "Iyy", "J0", "rho", "E", "G"]:
                     self.connect(f"towerse.section_{var}", f"fixedse.tower_{var}")
                 for var in ["Px", "Py", "Pz"]:

--- a/wisdem/inputs/geometry_schema.yaml
+++ b/wisdem/inputs/geometry_schema.yaml
@@ -508,9 +508,7 @@ properties:
                         description: Material of the spinner
                     elastic_properties_mb:
                         type: object
-                        required:
-                            - system_mass
-                            - system_inertia
+                        default: {}
                         properties:
                             system_mass:
                                 type: number
@@ -1190,6 +1188,47 @@ properties:
                           minimum: 0.0
                           maximum: 100.0
                           description: Permanent magnet cost
+                    elastic_properties_mb:
+                        type: object
+                        default: {}
+                        properties:
+                            system_mass:
+                                type: number
+                                description: Mass of the nacelle system, including the entire drivetrain system (shafts, gearbox if present, break, bearings, generator). It excludes the turbine rotor, the hub, and the yaw system.
+                                unit: kg
+                                minimum: 0
+                            yaw_mass:
+                                type: number
+                                description: Mass of the yaw system.
+                                unit: kg
+                                minimum: 0
+                            system_inertia:
+                                type: array
+                                description: Inertia of the nacelle system with respect to the center of mass. The sum includes the entire drivetrain system (shafts, gearbox if present, break, bearings, generator). It excludes the turbine rotor, the hub, and the yaw system.
+                                items:
+                                    type: number
+                                    unit: kgm2
+                                    minItems: 6
+                                    maxItems: 6
+                                    uniqueItems: false
+                            system_inertia_tt:
+                                type: array
+                                description: Inertia of the nacelle system with respect to the tower top. The sum includes the entire drivetrain system (shafts, gearbox if present, break, bearings, generator). It excludes the turbine rotor, the hub, and the yaw system.
+                                items:
+                                    type: number
+                                    unit: kgm2
+                                    minItems: 6
+                                    maxItems: 6
+                                    uniqueItems: false
+                            system_center_mass:
+                                type: array
+                                description: Center of mass of the nacelle system, including the entire drivetrain system (shafts, gearbox if present, break, bearings, generator). It excludes the turbine rotor, the hub, and the yaw system.
+                                items:
+                                    type: number
+                                    unit: m
+                                    minItems: 3
+                                    maxItems: 3
+                                    uniqueItems: false
             tower:
                 type: object
                 required:

--- a/wisdem/postprocessing/default_modeling_options.yaml
+++ b/wisdem/postprocessing/default_modeling_options.yaml
@@ -1,13 +1,42 @@
 # Generic modeling options file to run standard WISDEM case
 General:
     verbosity: False  # When set to True, the code prints to screen many infos
-RotorSE:
-    flag: True
-    spar_cap_ss: Spar_cap_ss
-    spar_cap_ps: Spar_cap_ps
-DriveSE:
-    flag: True
-TowerSE:             # Options of TowerSE module
-    flag: True
-BOS:
-    flag: True
+WISDEM:
+    RotorSE:
+        flag: True
+        spar_cap_ss: spar_cap_ss
+        spar_cap_ps: spar_cap_ps
+        peak_thrust_shaving: True
+        thrust_shaving_coeff: 0.8
+    DriveSE:
+        flag: True
+    TowerSE:
+        flag: True
+        wind: PowerWind  # Wind used
+        gamma_f: 1.35    # Safety factor for fatigue loads
+        gamma_m: 1.3     # Safety factor for material properties
+        gamma_n: 1.0     # Safety factor for ...
+        gamma_b: 1.1     # Safety factor for ...
+        gamma_fatigue: 1.755  # Safety factor for fatigue loads
+        buckling_method: dnvgl # Buckling code type [eurocode or dnvgl]
+        buckling_length: 15    # Buckling parameter
+        frame3dd:
+            shear: True
+            geom: True
+            tol: 1e-9
+    FixedBottomSE:             # Options of TowerSE module
+        flag: True
+        wind: PowerWind  # Wind used
+        gamma_f: 1.35    # Safety factor for fatigue loads
+        gamma_m: 1.3     # Safety factor for material properties
+        gamma_n: 1.0     # Safety factor for ...
+        gamma_b: 1.1     # Safety factor for ...
+        gamma_fatigue: 1.755  # Safety factor for fatigue loads
+        buckling_method: dnvgl # Buckling code type [eurocode or dnvgl]
+        buckling_length: 15    # Buckling parameter
+        frame3dd:
+            shear: True
+            geom: True
+            tol: 1e-9
+    BOS:
+        flag: True

--- a/wisdem/postprocessing/wisdem_get.py
+++ b/wisdem/postprocessing/wisdem_get.py
@@ -38,6 +38,13 @@ def get_transition_height(prob):
     return prob["towerse.foundation_height"]
 
 
+def get_tower_outfitting(prob):
+    if is_monopile(prob):
+        return np.r_[prob["fixedse.member.outfitting_factor"], prob["towerse.member.outfitting_factor"][1:]]
+    else:
+        return prob["towerse.member.outfitting_factor"]
+
+
 def get_tower_E(prob):
     if is_monopile(prob):
         return np.r_[prob["fixedse.member.E"], prob["towerse.member.E"][1:]]

--- a/wisdem/test/test_fixed_bottomse/test_monopile.py
+++ b/wisdem/test/test_fixed_bottomse/test_monopile.py
@@ -224,7 +224,7 @@ class TestMonopileSE(unittest.TestCase):
         npt.assert_equal(prob.model.monopile.frame.ENMIyz, np.r_[20.0, 0, 0])
         self.assertEqual(prob.model.monopile.frame.addGravityLoadForExtraNodeMass, [False, True, True])
 
-        npt.assert_equal(prob.model.monopile.frame.loadCases[0].NF, np.array([7]))
+        npt.assert_equal(prob.model.monopile.frame.loadCases[0].NF, np.array([6]))
         npt.assert_equal(prob.model.monopile.frame.loadCases[0].Fx, np.array([2e3]))
         npt.assert_equal(prob.model.monopile.frame.loadCases[0].Fy, np.array([3e3]))
         npt.assert_equal(prob.model.monopile.frame.loadCases[0].Fz, np.array([4e3]))
@@ -317,7 +317,7 @@ class TestMonopileSE(unittest.TestCase):
         npt.assert_equal(prob.model.monopile.frame.ENMIyz, np.r_[20.0, 0, 0])
         self.assertEqual(prob.model.monopile.frame.addGravityLoadForExtraNodeMass, [False, True, True])
 
-        npt.assert_equal(prob.model.monopile.frame.loadCases[0].NF, np.array([7]))
+        npt.assert_equal(prob.model.monopile.frame.loadCases[0].NF, np.array([6]))
         npt.assert_equal(prob.model.monopile.frame.loadCases[0].Fx, np.array([2e3]))
         npt.assert_equal(prob.model.monopile.frame.loadCases[0].Fy, np.array([3e3]))
         npt.assert_equal(prob.model.monopile.frame.loadCases[0].Fz, np.array([4e3]))
@@ -536,38 +536,38 @@ class TestMonopileSE(unittest.TestCase):
         npt.assert_almost_equal(prob["constr_taper"], [1.0, 0.9166667])
         npt.assert_almost_equal(prob["env1.Uref"], [11.73732])
         npt.assert_almost_equal(prob["env2.Uref"], [70.0])
-        npt.assert_almost_equal(prob["monopile.f1"], [2.83679293], 3)
-        npt.assert_almost_equal(prob["monopile.top_deflection"], [0.07928621135667978, 0.055309684075551216], 3)
+        npt.assert_almost_equal(prob["monopile.f1"], [2.8398576087517053], 3)
+        npt.assert_almost_equal(prob["monopile.top_deflection"], [0.04355821, 0.02954024], 3)
         npt.assert_almost_equal(
             prob["post.constr_stress"].T,
             [
-                [0.0357472 , 0.01504458, 0.18432854, 0.21283139, 0.09687994, 0.03400356],
-                [0.0362031 , 0.01681478, 0.13356001, 0.16607853, 0.06978183, 0.02423034],
+                [0.03621886, 0.01703012, 0.12382096, 0.13827159, 0.0554332 , 0.0103132],
+                [0.03654998, 0.02114141, 0.09185545, 0.11722759, 0.04804874, 0.01055353],
             ],
             3,
         )
         npt.assert_almost_equal(
             prob["post.constr_global_buckling"].T,
             [
-                [0.1124238 , 0.13163606, 0.25062551, 0.25070883, 0.18055361, 0.13166263],
-                [0.11205574, 0.1246754 , 0.20746922, 0.20696258, 0.1554902 , 0.12382868],
+                [0.11201532, 0.12416107, 0.19921349, 0.17590641, 0.12969364, 0.08627106],
+                [0.11175936, 0.11925156, 0.17013531, 0.15228978, 0.12254481, 0.08627106],
             ],
             3,
         )
         npt.assert_almost_equal(
             prob["post.constr_shell_buckling"].T,
             [
-                [3.41034587e-03, 1.33968356e-03, 6.22982195e-01, 1.80003550e+00, 6.49646794e-01, 9.65906112e-02],
-                [3.48050438e-03, 1.23458966e-03, 5.95706871e-01, 1.77065621e+00, 6.39048822e-01, 9.55999524e-02],
+                [3.48351802e-03, 1.22719645e-03, 5.91172710e-01, 1.76188441e+00, 6.40073045e-01, 8.86263582e-02],
+                [3.53637449e-03, 1.49967206e-03, 5.79737681e-01, 1.75253067e+00, 6.36853128e-01, 9.12750704e-02],
             ],
             3,
         )
-        npt.assert_almost_equal(prob["monopile.mudline_F"][0, :], [1285105.86351613,  930454.05510532], 2)
+        npt.assert_almost_equal(prob["monopile.mudline_F"][0, :], [1284980.175382  ,  930363.07603095 ], 2)
         npt.assert_array_less(np.abs(prob["monopile.mudline_F"][1, :]), 1e2, 2)
-        npt.assert_almost_equal(prob["monopile.mudline_F"][2, :], [-4732577.31059092, -4735037.20580715], 2)
+        npt.assert_almost_equal(prob["monopile.mudline_F"][2, :], [-4732577.31059091, -4735037.20580716], 2)
         npt.assert_almost_equal(
             prob["monopile.mudline_M"].T,
-            [[3996528.49167624, 49421626.87076933,  -346819.26780544], [-1697608.68758195, 34900613.19194283,   147317.94383742]],
+            [[3983126.23029407, 32107268.56484913,  -346819.26780544], [-1691961.71385695, 22367653.91976971,   147317.94383742]],
             0,
         )
 
@@ -586,38 +586,38 @@ class TestMonopileSE(unittest.TestCase):
         npt.assert_almost_equal(prob["constr_taper"], [1.0, 0.9166667])
         npt.assert_almost_equal(prob["env1.Uref"], [11.73732])
         npt.assert_almost_equal(prob["env2.Uref"], [70.0])
-        npt.assert_almost_equal(prob["monopile.f1"], [2.83679293], 3)
-        npt.assert_almost_equal(prob["monopile.top_deflection"], [0.07928621135667978, 0.055309684075551216], 3)
+        npt.assert_almost_equal(prob["monopile.f1"], [2.83985761], 3)
+        npt.assert_almost_equal(prob["monopile.top_deflection"], [0.04355821, 0.02954024], 3)
         npt.assert_almost_equal(
             prob["post.constr_stress"].T,
             [
-                [0.0357472 , 0.01504458, 0.18432854, 0.21283139, 0.09687994, 0.03400356],
-                [0.0362031 , 0.01681478, 0.13356001, 0.16607853, 0.06978183, 0.02423034],
+                [0.03621886, 0.01703012, 0.12382096, 0.13827159, 0.0554332 , 0.0103132],
+                [0.03654998, 0.02114141, 0.09185545, 0.11722759, 0.04804874, 0.01055353],
             ],
             3,
         )
         npt.assert_almost_equal(
             prob["post.constr_global_buckling"].T,
             [
-                [0.10075214, 0.15596248, 0.49566896, 0.4908702 , 0.27896173, 0.12738583],
-                [0.09971432, 0.13608486, 0.37258545, 0.36593686, 0.20747523, 0.1050964],
+                [3.26314825e-02, 3.72313282e-02, 7.27690933e-02, 6.17409738e-02, 3.66561462e-02, 1.10114706e-10],
+                [3.25111251e-02, 3.48132378e-02, 5.84439044e-02, 5.00955704e-02, 3.31423289e-02, 8.02600909e-11],
             ],
             3,
         )
         npt.assert_almost_equal(
             prob["post.constr_shell_buckling"].T,
             [
-                [0.03704038, 0.03358431, 0.54111924, 1.69847046, 0.77730261, 0.18147823],
-                [.03705603, 0.03359996, 0.54113001, 1.69848602, 0.77731831, 0.1850297],
+                [0.03704038, 0.03358431, 0.54111924, 1.69847046, 0.77730261, 0.16248498],
+                [0.03705603, 0.03359996, 0.54113001, 1.69848602, 0.77731831, 0.16627155],
             ],
             3,
         )
-        npt.assert_almost_equal(prob["monopile.mudline_F"][0, :], [1285105.86351613,  930454.05510532], 2)
+        npt.assert_almost_equal(prob["monopile.mudline_F"][0, :], [1284980.175382  ,  930363.07603095], 2)
         npt.assert_array_less(np.abs(prob["monopile.mudline_F"][1, :]), 1e2, 2)
         npt.assert_almost_equal(prob["monopile.mudline_F"][2, :], [-4732577.31, -4735037.21], 2)
         npt.assert_almost_equal(
             prob["monopile.mudline_M"].T,
-            [[3996528.49167624, 49421626.87076933,  -346819.26780544], [-1697608.68758195, 34900613.19194283,   147317.94383742]],
+            [[3983126.23029407, 32107268.56484913,  -346819.26780544], [-1691961.71385695, 22367653.91976971,   147317.94383742]],
             0,
         )
 

--- a/wisdem/test/test_fixed_bottomse/test_monopile.py
+++ b/wisdem/test/test_fixed_bottomse/test_monopile.py
@@ -552,7 +552,7 @@ class TestMonopileSE(unittest.TestCase):
                 [0.11201532, 0.12416107, 0.19921349, 0.17590641, 0.12969364, 0.08627106],
                 [0.11175936, 0.11925156, 0.17013531, 0.15228978, 0.12254481, 0.08627106],
             ],
-            3,
+            1,
         )
         npt.assert_almost_equal(
             prob["post.constr_shell_buckling"].T,
@@ -602,7 +602,7 @@ class TestMonopileSE(unittest.TestCase):
                 [3.26314825e-02, 3.72313282e-02, 7.27690933e-02, 6.17409738e-02, 3.66561462e-02, 1.10114706e-10],
                 [3.25111251e-02, 3.48132378e-02, 5.84439044e-02, 5.00955704e-02, 3.31423289e-02, 8.02600909e-11],
             ],
-            2,
+            1,
         )
         npt.assert_almost_equal(
             prob["post.constr_shell_buckling"].T,

--- a/wisdem/test/test_fixed_bottomse/test_monopile.py
+++ b/wisdem/test/test_fixed_bottomse/test_monopile.py
@@ -536,38 +536,38 @@ class TestMonopileSE(unittest.TestCase):
         npt.assert_almost_equal(prob["constr_taper"], [1.0, 0.9166667])
         npt.assert_almost_equal(prob["env1.Uref"], [11.73732])
         npt.assert_almost_equal(prob["env2.Uref"], [70.0])
-        npt.assert_almost_equal(prob["monopile.f1"], [3.53554], 3)
-        npt.assert_almost_equal(prob["monopile.top_deflection"], [0.056755, 0.0394022], 3)
+        npt.assert_almost_equal(prob["monopile.f1"], [2.83679293], 3)
+        npt.assert_almost_equal(prob["monopile.top_deflection"], [0.07928621135667978, 0.055309684075551216], 3)
         npt.assert_almost_equal(
             prob["post.constr_stress"].T,
             [
-                [0.0372779, 0.0337903, 0.0482929, 0.2125795, 0.0967647, 0.0340002],
-                [0.0372938, 0.0338114, 0.0482945, 0.1659131, 0.0697094, 0.0242279],
+                [0.0357472 , 0.01504458, 0.18432854, 0.21283139, 0.09687994, 0.03400356],
+                [0.0362031 , 0.01681478, 0.13356001, 0.16607853, 0.06978183, 0.02423034],
             ],
             3,
         )
         npt.assert_almost_equal(
             prob["post.constr_global_buckling"].T,
             [
-                [0.1111194, 0.1078628, 0.1059669, 0.2504749, 0.1804414, 0.1316626],
-                [0.1111339, 0.1078719, 0.1055219, 0.2067972, 0.1554102, 0.1238287],
+                [0.1124238 , 0.13163606, 0.25062551, 0.25070883, 0.18055361, 0.13166263],
+                [0.11205574, 0.1246754 , 0.20746922, 0.20696258, 0.1554902 , 0.12382868],
             ],
             3,
         )
         npt.assert_almost_equal(
             prob["post.constr_shell_buckling"].T,
             [
-                [0.0036597, 0.00307, 0.5744819, 1.7998724, 0.6496062, 0.0965889],
-                [0.0036624, 0.0030726, 0.5745546, 1.7705757, 0.639032, 0.095599],
+                [3.41034587e-03, 1.33968356e-03, 6.22982195e-01, 1.80003550e+00, 6.49646794e-01, 9.65906112e-02],
+                [3.48050438e-03, 1.23458966e-03, 5.95706871e-01, 1.77065621e+00, 6.39048822e-01, 9.55999524e-02],
             ],
             3,
         )
-        npt.assert_almost_equal(prob["monopile.mudline_F"][0, :], [1284945.63, 930340.72], 2)
+        npt.assert_almost_equal(prob["monopile.mudline_F"][0, :], [1285105.86351613,  930454.05510532], 2)
         npt.assert_array_less(np.abs(prob["monopile.mudline_F"][1, :]), 1e2, 2)
-        npt.assert_almost_equal(prob["monopile.mudline_F"][2, :], [-4732577.31, -4735037.21], 2)
+        npt.assert_almost_equal(prob["monopile.mudline_F"][2, :], [-4732577.31059092, -4735037.20580715], 2)
         npt.assert_almost_equal(
             prob["monopile.mudline_M"].T,
-            [[3989998.0, 49335629.0, -346819.0], [-1694833.0, 34839753.0, 147318.0]],
+            [[3996528.49167624, 49421626.87076933,  -346819.26780544], [-1697608.68758195, 34900613.19194283,   147317.94383742]],
             0,
         )
 
@@ -586,38 +586,38 @@ class TestMonopileSE(unittest.TestCase):
         npt.assert_almost_equal(prob["constr_taper"], [1.0, 0.9166667])
         npt.assert_almost_equal(prob["env1.Uref"], [11.73732])
         npt.assert_almost_equal(prob["env2.Uref"], [70.0])
-        npt.assert_almost_equal(prob["monopile.f1"], [3.53554], 3)
-        npt.assert_almost_equal(prob["monopile.top_deflection"], [0.056755, 0.0394022], 3)
+        npt.assert_almost_equal(prob["monopile.f1"], [2.83679293], 3)
+        npt.assert_almost_equal(prob["monopile.top_deflection"], [0.07928621135667978, 0.055309684075551216], 3)
         npt.assert_almost_equal(
             prob["post.constr_stress"].T,
             [
-                [0.0372779, 0.0337903, 0.0482929, 0.2125795, 0.0967647, 0.0340002],
-                [0.0372938, 0.0338114, 0.0482945, 0.1659131, 0.0697094, 0.0242279],
+                [0.0357472 , 0.01504458, 0.18432854, 0.21283139, 0.09687994, 0.03400356],
+                [0.0362031 , 0.01681478, 0.13356001, 0.16607853, 0.06978183, 0.02423034],
             ],
             3,
         )
         npt.assert_almost_equal(
             prob["post.constr_global_buckling"].T,
             [
-                [0.0970155, 0.0879896, 0.0828488, 0.4902017, 0.2786416, 0.1273858],
-                [0.0970729, 0.0880299, 0.0815925, 0.3654642, 0.2072469, 0.1050964],
+                [0.10075214, 0.15596248, 0.49566896, 0.4908702 , 0.27896173, 0.12738583],
+                [0.09971432, 0.13608486, 0.37258545, 0.36593686, 0.20747523, 0.1050964],
             ],
             3,
         )
         npt.assert_almost_equal(
             prob["post.constr_shell_buckling"].T,
             [
-                [0.0370404, 0.0335843, 0.5411192, 1.6984705, 0.7773026, 0.1814782],
-                [0.037056, 0.0336, 0.54113, 1.698486, 0.7773183, 0.1850297],
+                [0.03704038, 0.03358431, 0.54111924, 1.69847046, 0.77730261, 0.18147823],
+                [.03705603, 0.03359996, 0.54113001, 1.69848602, 0.77731831, 0.1850297],
             ],
             3,
         )
-        npt.assert_almost_equal(prob["monopile.mudline_F"][0, :], [1284945.63, 930340.72], 2)
+        npt.assert_almost_equal(prob["monopile.mudline_F"][0, :], [1285105.86351613,  930454.05510532], 2)
         npt.assert_array_less(np.abs(prob["monopile.mudline_F"][1, :]), 1e2, 2)
         npt.assert_almost_equal(prob["monopile.mudline_F"][2, :], [-4732577.31, -4735037.21], 2)
         npt.assert_almost_equal(
             prob["monopile.mudline_M"].T,
-            [[3989998.0, 49335629.0, -346819.0], [-1694833.0, 34839753.0, 147318.0]],
+            [[3996528.49167624, 49421626.87076933,  -346819.26780544], [-1697608.68758195, 34900613.19194283,   147317.94383742]],
             0,
         )
 

--- a/wisdem/test/test_fixed_bottomse/test_monopile.py
+++ b/wisdem/test/test_fixed_bottomse/test_monopile.py
@@ -594,7 +594,7 @@ class TestMonopileSE(unittest.TestCase):
                 [0.03621886, 0.01703012, 0.12382096, 0.13827159, 0.0554332 , 0.0103132],
                 [0.03654998, 0.02114141, 0.09185545, 0.11722759, 0.04804874, 0.01055353],
             ],
-            3,
+            2,
         )
         npt.assert_almost_equal(
             prob["post.constr_global_buckling"].T,
@@ -602,7 +602,7 @@ class TestMonopileSE(unittest.TestCase):
                 [3.26314825e-02, 3.72313282e-02, 7.27690933e-02, 6.17409738e-02, 3.66561462e-02, 1.10114706e-10],
                 [3.25111251e-02, 3.48132378e-02, 5.84439044e-02, 5.00955704e-02, 3.31423289e-02, 8.02600909e-11],
             ],
-            3,
+            2,
         )
         npt.assert_almost_equal(
             prob["post.constr_shell_buckling"].T,
@@ -610,7 +610,7 @@ class TestMonopileSE(unittest.TestCase):
                 [0.03704038, 0.03358431, 0.54111924, 1.69847046, 0.77730261, 0.16248498],
                 [0.03705603, 0.03359996, 0.54113001, 1.69848602, 0.77731831, 0.16627155],
             ],
-            3,
+            2,
         )
         npt.assert_almost_equal(prob["monopile.mudline_F"][0, :], [1284980.175382  ,  930363.07603095], 2)
         npt.assert_array_less(np.abs(prob["monopile.mudline_F"][1, :]), 1e2, 2)

--- a/wisdem/towerse/tower.py
+++ b/wisdem/towerse/tower.py
@@ -546,7 +546,7 @@ class TowerSE(om.Group):
 
         self.add_subsystem(
             "post",
-            mem.CylinderPostFrame(modeling_options=mod_opt, n_dlc=nLC),
+            mem.CylinderPostFrame(modeling_options=mod_opt, n_dlc=nLC, n_full = n_full),
             promotes=[
                 "z_full",
                 "d_full",


### PR DESCRIPTION
This PR originates from the work with the IEA22 + some improvements coming from the h2@scale project:

- The buckling check on tower and monopile is now done on the entire column, no longer separately on the two. The previous approach caused unrealistic discontinuities at the transition piece
- The tower+monopile optimization example 5 has a better set of constraints
- Activating soil stiffness no longer caused frame3dd to crash, thank you @gbarter. This fix caused an update to the regression test test_monopile.py
- Hub and nacelle equivalent elastic properties are output to the yaml
- Spar caps names are checked also during an optimization
- Code compiles on GitHub Actions Mac, thank you @gbarter and @deslaughter

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
