### PR TITLE
Fix Viterna extrapolation bug to avoid repeated data

### DIFF
--- a/wisdem/ccblade/Polar.py
+++ b/wisdem/ccblade/Polar.py
@@ -350,6 +350,8 @@ class Polar(object):
         # -90 <-> -alpha_high
         alpha5 = np.linspace(-np.pi / 2, alpha5max, nalpha)
         alpha5 = alpha5[1:]
+        if alpha_low == -alpha_high:
+            alpha5 = alpha5[:-2]
         cl5, cd5 = self.__Viterna(-alpha5, -cl_adj)
 
         # -180+alpha_high <-> -90

--- a/wisdem/ccblade/Polar.py
+++ b/wisdem/ccblade/Polar.py
@@ -351,7 +351,7 @@ class Polar(object):
         alpha5 = np.linspace(-np.pi / 2, alpha5max, nalpha)
         alpha5 = alpha5[1:]
         if alpha_low == -alpha_high:
-            alpha5 = alpha5[:-2]
+            alpha5 = alpha5[:-1]
         cl5, cd5 = self.__Viterna(-alpha5, -cl_adj)
 
         # -180+alpha_high <-> -90


### PR DESCRIPTION
## Purpose
Fix a small bug in Viterna extrapolation code where if `alpha_low == -alpha_high`, then the code repeats the data corresponding to `alpha_low` in the resulting extrapolation. This causes OpenFAST to error out due to duplicate `alpha` in the airfoil polar files.

## Type of change
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which
 adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Try the Viterna extension with this [code](https://github.com/WISDEM/WISDEM/files/12887481/ViternaExtensionOfDeltaPolars.txt)  (rename code to .py) and with [this](https://github.com/WISDEM/WISDEM/files/12887491/Polar_LowARDelta.txt) file in the same folder.

## Checklist
- [X] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
