### PR TITLE
update regression values for gearbox L and D

### DIFF
--- a/wisdem/drivetrainse/gearbox.py
+++ b/wisdem/drivetrainse/gearbox.py
@@ -260,8 +260,8 @@ class Gearbox(om.ExplicitComponent):
 
             # calculate mass properties
             D_rotor = inputs["rotor_diameter"]
-            L_gearbox = 0.012 * D_rotor
-            R_gearbox = 0.5 * 0.75 * 0.015 * D_rotor
+            L_gearbox = 0.015 * D_rotor # assumed to be 1.5% of wind turbine rotor, regression from Jan 30th, 2024 
+            R_gearbox = 0.006 * D_rotor # assumed to be 0.6% of wind turbine rotor, regression from Jan 30th, 2024 
         else:
             m_gearbox = inputs["gearbox_mass_user"]
             R_gearbox = inputs["gearbox_radius_user"]

--- a/wisdem/drivetrainse/gearbox.py
+++ b/wisdem/drivetrainse/gearbox.py
@@ -260,8 +260,8 @@ class Gearbox(om.ExplicitComponent):
 
             # calculate mass properties
             D_rotor = inputs["rotor_diameter"]
-            L_gearbox = 0.015 * D_rotor # assumed to be 1.5% of wind turbine rotor, regression from Jan 30th, 2024 
-            R_gearbox = 0.006 * D_rotor # assumed to be 0.6% of wind turbine rotor, regression from Jan 30th, 2024 
+            L_gearbox = 0.015 * D_rotor # assumed to be 1.5% of wind turbine rotor diameter, regression from Jan 30th, 2024 
+            R_gearbox = 0.006 * D_rotor # assumed to be 0.6% of wind turbine rotor diameter, regression from Jan 30th, 2024 
         else:
             m_gearbox = inputs["gearbox_mass_user"]
             R_gearbox = inputs["gearbox_radius_user"]

--- a/wisdem/test/test_drivetrainse/test_gearbox.py
+++ b/wisdem/test/test_drivetrainse/test_gearbox.py
@@ -52,8 +52,8 @@ class TestGearbox(unittest.TestCase):
             * (0.75 * self.outputs["D_gearbox"] ** 2 + self.outputs["L_gearbox"] ** 2)
             / 12.0,
         )
-        self.assertEqual(self.outputs["L_gearbox"], 0.012 * 126.0)
-        self.assertEqual(self.outputs["D_gearbox"], 0.75 * 0.015 * 126.0)
+        self.assertEqual(self.outputs["L_gearbox"], 0.015 * 126.0)
+        self.assertEqual(self.outputs["D_gearbox"], 0.012 * 126.0)
 
     def testEEP3(self):
         self.discrete_inputs["gear_configuration"] = "eep_3"
@@ -72,8 +72,8 @@ class TestGearbox(unittest.TestCase):
             * (0.75 * self.outputs["D_gearbox"] ** 2 + self.outputs["L_gearbox"] ** 2)
             / 12.0,
         )
-        self.assertEqual(self.outputs["L_gearbox"], 0.012 * 126.0)
-        self.assertEqual(self.outputs["D_gearbox"], 0.75 * 0.015 * 126.0)
+        self.assertEqual(self.outputs["L_gearbox"], 0.015 * 126.0)
+        self.assertEqual(self.outputs["D_gearbox"], 0.012 * 126.0)
 
     def testEEP2(self):
         self.discrete_inputs["gear_configuration"] = "eep_2"
@@ -92,8 +92,8 @@ class TestGearbox(unittest.TestCase):
             * (0.75 * self.outputs["D_gearbox"] ** 2 + self.outputs["L_gearbox"] ** 2)
             / 12.0,
         )
-        self.assertEqual(self.outputs["L_gearbox"], 0.012 * 126.0)
-        self.assertEqual(self.outputs["D_gearbox"], 0.75 * 0.015 * 126.0)
+        self.assertEqual(self.outputs["L_gearbox"], 0.015 * 126.0)
+        self.assertEqual(self.outputs["D_gearbox"], 0.012 * 126.0)
 
     def testEEP_planet4_1(self):
         self.discrete_inputs["gear_configuration"] = "eep"
@@ -112,8 +112,8 @@ class TestGearbox(unittest.TestCase):
             * (0.75 * self.outputs["D_gearbox"] ** 2 + self.outputs["L_gearbox"] ** 2)
             / 12.0,
         )
-        self.assertEqual(self.outputs["L_gearbox"], 0.012 * 126.0)
-        self.assertEqual(self.outputs["D_gearbox"], 0.75 * 0.015 * 126.0)
+        self.assertEqual(self.outputs["L_gearbox"], 0.015 * 126.0)
+        self.assertEqual(self.outputs["D_gearbox"], 0.012 * 126.0)
 
     def testEEP_planet4_2(self):
         self.discrete_inputs["gear_configuration"] = "eep"
@@ -132,8 +132,8 @@ class TestGearbox(unittest.TestCase):
             * (0.75 * self.outputs["D_gearbox"] ** 2 + self.outputs["L_gearbox"] ** 2)
             / 12.0,
         )
-        self.assertEqual(self.outputs["L_gearbox"], 0.012 * 126.0)
-        self.assertEqual(self.outputs["D_gearbox"], 0.75 * 0.015 * 126.0)
+        self.assertEqual(self.outputs["L_gearbox"], 0.015 * 126.0)
+        self.assertEqual(self.outputs["D_gearbox"], 0.012 * 126.0)
 
     def testEPP(self):
         self.discrete_inputs["gear_configuration"] = "epp"
@@ -151,8 +151,8 @@ class TestGearbox(unittest.TestCase):
             * (0.75 * self.outputs["D_gearbox"] ** 2 + self.outputs["L_gearbox"] ** 2)
             / 12.0,
         )
-        self.assertEqual(self.outputs["L_gearbox"], 0.012 * 126.0)
-        self.assertEqual(self.outputs["D_gearbox"], 0.75 * 0.015 * 126.0)
+        self.assertEqual(self.outputs["L_gearbox"], 0.015 * 126.0)
+        self.assertEqual(self.outputs["D_gearbox"], 0.012 * 126.0)
 
     def testLargeMachine(self):
         self.inputs["gear_ratio"] = 200.0
@@ -172,8 +172,8 @@ class TestGearbox(unittest.TestCase):
             * (0.75 * self.outputs["D_gearbox"] ** 2 + self.outputs["L_gearbox"] ** 2)
             / 12.0,
         )
-        self.assertEqual(self.outputs["L_gearbox"], 0.012 * 200.0)
-        self.assertEqual(self.outputs["D_gearbox"], 0.75 * 0.015 * 200.0)
+        self.assertEqual(self.outputs["L_gearbox"], 0.015 * 200.0)
+        self.assertEqual(self.outputs["D_gearbox"], 0.012 * 200.0)
 
     def testUserOverride(self):
         self.inputs["gear_ratio"] = 200.0


### PR DESCRIPTION
## Purpose
Adjust regression lines behind length and radius (or diameter) of the gearbox. These are now set equal to 1.5% and 0.6% (or 1.2%) of wind turbine rotor diameter

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
