### PR TITLE
Correct typo in setting user constraints

### DIFF
--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -1388,8 +1388,8 @@ class PoseOptimization(object):
                 
             if "upper_bound" in user_constr[k]:
                 upper_k = user_constr[k]["upper_bound"]
-            elif "lower" in user_constr[k]:
-                lower_k = user_constr[k]["lower"]
+            elif "upper" in user_constr[k]:
+                upper_k = user_constr[k]["upper"]
             else:
                 upper_k = None
                 


### PR DESCRIPTION
The `lower_k` variable was being set where the `upper_k` variable should have been being set.

## Purpose
Correct user constraint setting

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
