### PR TITLE
bedplate mass fix for downwind direct drive systems

### DIFF
--- a/wisdem/drivetrainse/layout.py
+++ b/wisdem/drivetrainse/layout.py
@@ -307,8 +307,10 @@ class DirectLayout(Layout):
         n_points = 12
         if upwind:
             rad = np.linspace(0.0, 0.5 * np.pi, n_points)
+            dw = 1
         else:
             rad = np.linspace(np.pi, 0.5 * np.pi, n_points)
+            dw = -1
 
         # Make sure we have the right number of bedplate thickness points
         t_bed = np.interp(rad, np.linspace(rad[0], rad[-1], len(t_bed)), t_bed)
@@ -332,7 +334,7 @@ class DirectLayout(Layout):
         A_bed = np.pi * (r_bed_o**2 - r_bed_i**2)
 
         # This finds the central angle (rad2) given the parametric angle (rad)
-        rad2 = np.arctan(L_bedplate / H_bedplate * np.tan(rad))
+        rad2 = np.arctan2(z_c/H_bedplate, dw * x_c/L_bedplate)
 
         # arc length from eccentricity of the centroidal ellipse using incomplete elliptic integral of the second kind
         if L_bedplate >= H_bedplate:

--- a/wisdem/test/test_drivetrainse/test_layout.py
+++ b/wisdem/test/test_drivetrainse/test_layout.py
@@ -282,6 +282,44 @@ class TestDirectLayout(unittest.TestCase):
             self.outputs["nose_I"][1], (1 / 12) * m_nose * (3 * (1.5**2 + 1.45**2) + self.outputs["L_nose"] ** 2)
         )
 
+    def testMassValuesDownwind(self):
+        self.discrete_inputs["upwind"] = False
+        self.inputs["tilt"] = 0.0
+        self.inputs["drive_height"] = 5.0
+        self.inputs["D_top"] = 3.0
+        self.inputs["overhang"] = 4.5 + 3.5 + 0.5 * 3.0 + 2
+        myones = np.ones(5)
+        self.inputs["lss_diameter"] = 2.0 * myones
+        self.inputs["nose_diameter"] = 3.0 * myones
+        self.inputs["lss_wall_thickness"] = 0.05 * myones
+        self.inputs["nose_wall_thickness"] = 0.05 * myones
+        self.inputs["bedplate_wall_thickness"] = 0.05 * np.ones(npts)
+        myobj = lay.DirectLayout()
+        myobj.compute(self.inputs, self.outputs, self.discrete_inputs, self.discrete_outputs)
+
+        rho = self.inputs["lss_rho"]
+        m_bedplate = 5 * 0.5 * np.pi * np.pi * (1.5**2 - (1.5 - 0.05) ** 2) * rho
+        self.assertAlmostEqual(self.outputs["bedplate_mass"], m_bedplate)
+        self.assertAlmostEqual(self.outputs["bedplate_cm"][0], np.mean(self.outputs["x_bedplate"]), 0)
+        self.assertAlmostEqual(self.outputs["bedplate_cm"][1], 0.0)
+        self.assertAlmostEqual(self.outputs["bedplate_cm"][2], np.mean(self.outputs["z_bedplate"]), 0)
+
+        m_lss = rho * np.pi * (1**2 - 0.95**2) * self.outputs["L_lss"]
+        self.assertAlmostEqual(self.outputs["lss_mass"], m_lss)
+        self.assertAlmostEqual(self.outputs["lss_cm"], 0.5 * (self.outputs["s_lss"][0] + self.outputs["s_lss"][-1]))
+        self.assertAlmostEqual(self.outputs["lss_I"][0], 0.5 * m_lss * (1**2 + 0.95**2))
+        self.assertAlmostEqual(
+            self.outputs["lss_I"][1], (1 / 12) * m_lss * (3 * (1**2 + 0.95**2) + self.outputs["L_lss"] ** 2)
+        )
+
+        m_nose = rho * np.pi * (1.5**2 - 1.45**2) * self.outputs["L_nose"]
+        self.assertAlmostEqual(self.outputs["nose_mass"], m_nose)
+        self.assertAlmostEqual(self.outputs["nose_cm"], 0.5 * (self.outputs["s_nose"][0] + self.outputs["s_nose"][-1]))
+        self.assertAlmostEqual(self.outputs["nose_I"][0], 0.5 * m_nose * (1.5**2 + 1.45**2))
+        self.assertAlmostEqual(
+            self.outputs["nose_I"][1], (1 / 12) * m_nose * (3 * (1.5**2 + 1.45**2) + self.outputs["L_nose"] ** 2)
+        )
+
 
 class TestGearedLayout(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Purpose
Fix to address bedplate mass going negative when the turbine is in downwind configuration and has a direct drive system. The limitations of the `np.arctan` function caused a step change in the angles being computed for a downwind turbine. Current fix replaces it with `np.arctan2`. There are no changes in the results for the upwind configuration. I'm open to suggestions to make the fix more pythonic.

## Type of change
What types of change is it?
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
New test `testMassValuesDownwind` added to account for downwind turbines with direct-drive systems.

## Checklist
- [ ] I have run existing tests which pass locally with my changes
- [x] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
