### PR TITLE
fix bug in bedplate length offset of drive components

### DIFF
--- a/wisdem/drivetrainse/layout.py
+++ b/wisdem/drivetrainse/layout.py
@@ -282,6 +282,7 @@ class DirectLayout(Layout):
         outputs["H_bedplate"] = H_bedplate
 
         # Discretize the drivetrain from bedplate to hub
+        s_drive += L_bedplate
         s_mb1 = s_drive[4]
         s_mb2 = s_drive[2]
         s_rotor = s_drive[-2]

--- a/wisdem/test/test_drivetrainse/test_layout.py
+++ b/wisdem/test/test_drivetrainse/test_layout.py
@@ -82,10 +82,10 @@ class TestDirectLayout(unittest.TestCase):
         self.assertAlmostEqual(self.outputs["constr_length"], 5 - 0.5 * 6.5)
         self.assertAlmostEqual(self.outputs["constr_height"], self.outputs["H_bedplate"])
 
-        self.assertAlmostEqual(self.outputs["s_rotor"], 2 + 1.5 + 0.5)
-        self.assertAlmostEqual(self.outputs["s_stator"], 0.75)
-        self.assertAlmostEqual(self.outputs["s_mb1"], 1.5 + 2.0)
-        self.assertAlmostEqual(self.outputs["s_mb2"], 1.5)
+        self.assertAlmostEqual(self.outputs["s_rotor"], self.outputs["L_bedplate"] + 2 + 1.5 + 0.5)
+        self.assertAlmostEqual(self.outputs["s_stator"], self.outputs["L_bedplate"] + 0.75)
+        self.assertAlmostEqual(self.outputs["s_mb1"], self.outputs["L_bedplate"] + 1.5 + 2.0)
+        self.assertAlmostEqual(self.outputs["s_mb2"], self.outputs["L_bedplate"] + 1.5)
 
         self.assertAlmostEqual(self.outputs["x_bedplate"][-1], -5.0)
         self.assertAlmostEqual(self.outputs["x_bedplate_inner"][-1], -5.0)
@@ -130,10 +130,10 @@ class TestDirectLayout(unittest.TestCase):
         )
         self.assertAlmostEqual(self.outputs["constr_height"], self.outputs["H_bedplate"])
 
-        self.assertAlmostEqual(self.outputs["s_rotor"], 2 + 1.5 + 0.5)
-        self.assertAlmostEqual(self.outputs["s_stator"], 0.75)
-        self.assertAlmostEqual(self.outputs["s_mb1"], 1.5 + 2.0)
-        self.assertAlmostEqual(self.outputs["s_mb2"], 1.5)
+        self.assertAlmostEqual(self.outputs["s_rotor"], self.outputs["L_bedplate"] + 2 + 1.5 + 0.5)
+        self.assertAlmostEqual(self.outputs["s_stator"], self.outputs["L_bedplate"] + 0.75)
+        self.assertAlmostEqual(self.outputs["s_mb1"], self.outputs["L_bedplate"] + 1.5 + 2.0)
+        self.assertAlmostEqual(self.outputs["s_mb2"], self.outputs["L_bedplate"] + 1.5)
 
         self.assertAlmostEqual(self.outputs["x_bedplate"][-1], -5.0)
         self.assertAlmostEqual(self.outputs["x_bedplate_inner"][-1], -5.0)
@@ -172,10 +172,10 @@ class TestDirectLayout(unittest.TestCase):
         self.assertAlmostEqual(self.outputs["constr_length"], 5 - 0.5 * 6.5)
         self.assertAlmostEqual(self.outputs["constr_height"], self.outputs["H_bedplate"])
 
-        self.assertAlmostEqual(self.outputs["s_rotor"], 2 + 1.5 + 0.5)
-        self.assertAlmostEqual(self.outputs["s_stator"], 0.75)
-        self.assertAlmostEqual(self.outputs["s_mb1"], 1.5 + 2.0)
-        self.assertAlmostEqual(self.outputs["s_mb2"], 1.5)
+        self.assertAlmostEqual(self.outputs["s_rotor"], self.outputs["L_bedplate"] + 2 + 1.5 + 0.5)
+        self.assertAlmostEqual(self.outputs["s_stator"], self.outputs["L_bedplate"] + 0.75)
+        self.assertAlmostEqual(self.outputs["s_mb1"], self.outputs["L_bedplate"] + 1.5 + 2.0)
+        self.assertAlmostEqual(self.outputs["s_mb2"], self.outputs["L_bedplate"] + 1.5)
 
         self.assertAlmostEqual(self.outputs["x_bedplate"][-1], 5.0)
         self.assertAlmostEqual(self.outputs["x_bedplate_inner"][-1], 5.0)
@@ -221,10 +221,10 @@ class TestDirectLayout(unittest.TestCase):
         )
         self.assertAlmostEqual(self.outputs["constr_height"], self.outputs["H_bedplate"])
 
-        self.assertAlmostEqual(self.outputs["s_rotor"], 2 + 1.5 + 0.5)
-        self.assertAlmostEqual(self.outputs["s_stator"], 0.75)
-        self.assertAlmostEqual(self.outputs["s_mb1"], 1.5 + 2.0)
-        self.assertAlmostEqual(self.outputs["s_mb2"], 1.5)
+        self.assertAlmostEqual(self.outputs["s_rotor"], self.outputs["L_bedplate"] + 2 + 1.5 + 0.5)
+        self.assertAlmostEqual(self.outputs["s_stator"], self.outputs["L_bedplate"] + 0.75)
+        self.assertAlmostEqual(self.outputs["s_mb1"], self.outputs["L_bedplate"] + 1.5 + 2.0)
+        self.assertAlmostEqual(self.outputs["s_mb2"], self.outputs["L_bedplate"] + 1.5)
 
         self.assertAlmostEqual(self.outputs["x_bedplate"][-1], 5.0)
         self.assertAlmostEqual(self.outputs["x_bedplate_inner"][-1], 5.0)


### PR DESCRIPTION
## Purpose
Credit to @verlivkra in https://github.com/IEAWindTask37/IEA-15-240-RWT/issues/199.

In the direct-drive layout, the drive component locations were not offset by the bedplate length.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [x] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
