### PR TITLE
Switch to nikhar's rank_and_file method (with vectorization) for ElastoDyn coefficients

### DIFF
--- a/wisdem/fixed_bottomse/monopile.py
+++ b/wisdem/fixed_bottomse/monopile.py
@@ -654,6 +654,7 @@ class MonopileFrame(om.ExplicitComponent):
             modal.zmpf,
             idx0=NREFINE,
             base_slope0=(not self.options["soil_springs"]),
+            rank_and_file=True,            
         )
         outputs["fore_aft_freqs"] = freq_x[:NFREQ2]
         outputs["side_side_freqs"] = freq_y[:NFREQ2]

--- a/wisdem/rotorse/rotor_structure.py
+++ b/wisdem/rotorse/rotor_structure.py
@@ -507,7 +507,8 @@ class RunFrame3DD(ExplicitComponent):
         # Mode shapes and frequencies
         n_freq2 = int(self.n_freq / 2)
         freq_x, freq_y, freq_z, mshapes_x, mshapes_y, mshapes_z = util.get_xyz_mode_shapes(
-            r, modal.freq, modal.xdsp, modal.ydsp, modal.zdsp, modal.xmpf, modal.ympf, modal.zmpf
+            r, modal.freq, modal.xdsp, modal.ydsp, modal.zdsp, modal.xmpf, modal.ympf, modal.zmpf,
+            rank_and_file=True,
         )
         freq_x = freq_x[:n_freq2]
         freq_y = freq_y[:n_freq2]

--- a/wisdem/test/test_commonse/test_utilities.py
+++ b/wisdem/test/test_commonse/test_utilities.py
@@ -1,4 +1,5 @@
 import unittest
+import time
 
 import numpy as np
 import numpy.testing as npt
@@ -208,10 +209,12 @@ class TestAny(unittest.TestCase):
         ym = np.random.random(n)
         zm = np.random.random(n)
 
+        #t0 = time.time()
         freq_x, freq_y, freq_z, mshapes_x, mshapes_y, mshapes_z = util.get_xyz_mode_shapes(
             r, freqs, dx, dy, dz, xm, ym, zm, rank_and_file=True
         )
-
+        #print(time.time() - t0)
+        
         # Ensure each mode shape's coefficients sum to 1
         npt.assert_almost_equal(np.sum(mshapes_x, axis=1), np.ones(n2))
         npt.assert_almost_equal(np.sum(mshapes_y, axis=1), np.ones(n2))

--- a/wisdem/towerse/tower.py
+++ b/wisdem/towerse/tower.py
@@ -388,7 +388,8 @@ class TowerFrame(om.ExplicitComponent):
         # Get all mode shapes in batch
         NFREQ2 = int(NFREQ / 2)
         freq_x, freq_y, freq_z, mshapes_x, mshapes_y, mshapes_z = util.get_xyz_mode_shapes(
-            xyz[:, 2], modal.freq, modal.xdsp, modal.ydsp, modal.zdsp, modal.xmpf, modal.ympf, modal.zmpf
+            xyz[:, 2], modal.freq, modal.xdsp, modal.ydsp, modal.zdsp, modal.xmpf, modal.ympf, modal.zmpf,
+            rank_and_file=True,
         )
         outputs["fore_aft_freqs"] = freq_x[:NFREQ2]
         outputs["side_side_freqs"] = freq_y[:NFREQ2]


### PR DESCRIPTION
## Purpose
The faster and more robust method continues to give incorrect mode shapes.  The tower ED coefficients for the 22mw are  incorrect.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [x] I have added new tests or examples that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
