### PR TITLE
Change platform_elem_memid to a modeling option

### DIFF
--- a/wisdem/floatingse/floating_system.py
+++ b/wisdem/floatingse/floating_system.py
@@ -355,7 +355,7 @@ class PlatformFrame(om.ExplicitComponent):
         outputs["platform_elem_G"][:nelem] = elem_G
         outputs["platform_elem_TorsC"][:nelem] = elem_TorsC
         outputs["platform_elem_sigma_y"][:nelem] = elem_sigy
-        discrete_outputs["platform_elem_memid"] = elem_memid
+        opt['floating']['members']['platform_elem_memid'] = elem_memid  # converted from discrte_output to modeling option
 
         outputs["platform_ballast_mass"] = m_ball
         outputs["platform_hull_mass"] = mass - m_ball

--- a/wisdem/floatingse/floating_system.py
+++ b/wisdem/floatingse/floating_system.py
@@ -355,7 +355,7 @@ class PlatformFrame(om.ExplicitComponent):
         outputs["platform_elem_G"][:nelem] = elem_G
         outputs["platform_elem_TorsC"][:nelem] = elem_TorsC
         outputs["platform_elem_sigma_y"][:nelem] = elem_sigy
-        opt['floating']['members']['platform_elem_memid'] = elem_memid  # converted from discrte_output to modeling option
+        opt['floating']['members']['platform_elem_memid'] = elem_memid  # converted from discrete_output to modeling option
 
         outputs["platform_ballast_mass"] = m_ball
         outputs["platform_hull_mass"] = mass - m_ball

--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -1360,6 +1360,8 @@ class PoseOptimization(object):
         if float_constr["metacentric_height"]["flag"]:
             wt_opt.model.add_constraint(
                 "floatingse.metacentric_height_roll", lower=float_constr["metacentric_height"]["lower_bound"]
+            )
+            wt_opt.model.add_constraint(
                 "floatingse.metacentric_height_pitch", lower=float_constr["metacentric_height"]["lower_bound"]
             )
 

--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -1359,7 +1359,8 @@ class PoseOptimization(object):
 
         if float_constr["metacentric_height"]["flag"]:
             wt_opt.model.add_constraint(
-                "floatingse.metacentric_height", lower=float_constr["metacentric_height"]["lower_bound"]
+                "floatingse.metacentric_height_roll", lower=float_constr["metacentric_height"]["lower_bound"]
+                "floatingse.metacentric_height_pitch", lower=float_constr["metacentric_height"]["lower_bound"]
             )
 
         if float_constr["freeboard_margin"]["flag"]:


### PR DESCRIPTION
## Purpose
When running a WEIS optimization that requires `approx_totals`, we get the following error:
```
Total derivative with respect to 'wisdem.wt.wt_prop.wt_init.floating.joints.jointdv_0' depends upon discrete output variables ['wisdem.wt.floatingse.perf.sys.plat.platform_elem_memid'].
```
Converting discrete outputs/inputs to modeling options was the workaround when we encountered this previously.

`platform_elem_memid` does not seem to be used anywhere else in WISDEM.  It's used to set up OpenFAST inputs in `openmdao_openfast.py`.


## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
