### PR TITLE
Minor fix for numpy 2.0

### DIFF
--- a/wisdem/ccblade/Polar.py
+++ b/wisdem/ccblade/Polar.py
@@ -1844,7 +1844,7 @@ def _intersections(x1, y1, x2, y2, plot=False, minDist=1e-6, verbose=False):
     """
     INTERSECTIONS Intersections of curves.
     Computes the (x,y) locations where two curves intersect.  The curves
-    can be broken with NaNs or have vertical segments.
+    can be broken with nans or have vertical segments.
 
     Written by: Sukhbinder, https://github.com/sukhbinder/intersection
     adapted by E.Branlard to allow for minimum distance between points
@@ -1915,7 +1915,7 @@ def _intersections(x1, y1, x2, y2, plot=False, minDist=1e-6, verbose=False):
         try:
             T[:, i] = np.linalg.solve(AA[:, :, i], BB[:, i])
         except:
-            T[:, i] = np.NaN
+            T[:, i] = np.nan
 
     in_range = (T[0, :] >= 0) & (T[1, :] >= 0) & (T[0, :] <= 1) & (T[1, :] <= 1)
 

--- a/wisdem/ccblade/ccblade.py
+++ b/wisdem/ccblade/ccblade.py
@@ -997,7 +997,7 @@ class CCBlade(object):
             ) = self.__loads(phi_star, rotating, *args)
 
             if np.isnan(Np[i]):
-                print(f"NaNs at {i}/{n}: {phi_lower} {phi_star} {phi_upper}")
+                print(f"nans at {i}/{n}: {phi_lower} {phi_star} {phi_upper}")
                 a[i] = 0.0
                 ap[i] = 0.0
                 Np[i] = 0.0

--- a/wisdem/commonse/cross_sections.py
+++ b/wisdem/commonse/cross_sections.py
@@ -68,7 +68,7 @@ class Tube(CrossSectionBase):
     """The Tube Class contains functions to calculate properties of tubular circular cross-sections
     for structural analyses."""
 
-    def __init__(self, D, t, L=np.NaN, Kbuck=1.0):
+    def __init__(self, D, t, L=np.nan, Kbuck=1.0):
         self.D = D
         self.R = 0.5 * D
         self.t = t

--- a/wisdem/landbosse/model/CollectionCost.py
+++ b/wisdem/landbosse/model/CollectionCost.py
@@ -387,7 +387,7 @@ class ArraySystem(CostModule):
 
         # Check to make sure there aren't any zeros in num_turbines_per_cable, which is used as the denominator
         # in the division above (this happens when not all of the cable types in the input sheet need to be used).
-        # If there is a zero, then print a warning and change NaN to 0 in perc_partial_string.
+        # If there is a zero, then print a warning and change nan to 0 in perc_partial_string.
         if 0.0 in num_turb_per_cable:
             print(
                 f'Warning: {self.project_name} CollectionCost module generates number of turbines per string that '

--- a/wisdem/orbit/core/vessel.py
+++ b/wisdem/orbit/core/vessel.py
@@ -93,7 +93,7 @@ class Vessel(Agent):
             self.day_rate = self.config["vessel_specs"]["day_rate"]
 
         except KeyError:
-            self.day_rate = np.NaN
+            self.day_rate = np.nan
 
     def mobilize(self):
         """
@@ -390,9 +390,9 @@ class Vessel(Agent):
         if storage is None:
             raise Exception("Vessel does not have storage capacity.")
 
-        _cargo = storage.current_cargo_mass if cargo else np.NaN
-        _deck = storage.current_deck_space if deck else np.NaN
-        _items = dict(Counter(i for i in storage.items)) if items else np.NaN
+        _cargo = storage.current_cargo_mass if cargo else np.nan
+        _deck = storage.current_deck_space if deck else np.nan
+        _items = dict(Counter(i for i in storage.items)) if items else np.nan
 
         trip = Trip(cargo_mass=_cargo, deck_space=_deck, items=_items)
 
@@ -413,7 +413,7 @@ class Vessel(Agent):
             return np.array(self.cargo_mass_list) / max_cargo_mass
 
         except MissingComponent:
-            return np.array(np.NaN)
+            return np.array(np.nan)
 
     @property
     def deck_space_list(self):
@@ -430,14 +430,14 @@ class Vessel(Agent):
             return np.array(self.deck_space_list) / max_deck_space
 
         except MissingComponent:
-            return np.array(np.NaN)
+            return np.array(np.nan)
 
     @property
     def max_cargo_mass_utilization(self):
         """Returns maximum cargo mass utilization."""
 
         if not self.trip_data:
-            return np.NaN
+            return np.nan
 
         return np.max(self.cargo_mass_utilizations)
 
@@ -446,7 +446,7 @@ class Vessel(Agent):
         """Returns minimum cargo mass utilization."""
 
         if not self.trip_data:
-            return np.NaN
+            return np.nan
 
         return np.min(self.cargo_mass_utilizations)
 
@@ -455,7 +455,7 @@ class Vessel(Agent):
         """Returns mean cargo mass utilization."""
 
         if not self.trip_data:
-            return np.NaN
+            return np.nan
 
         return np.mean(self.cargo_mass_utilizations)
 
@@ -464,7 +464,7 @@ class Vessel(Agent):
         """Returns median cargo mass utilization."""
 
         if not self.trip_data:
-            return np.NaN
+            return np.nan
 
         return np.median(self.cargo_mass_utilizations)
 
@@ -473,7 +473,7 @@ class Vessel(Agent):
         """Returns maximum deck_space utilization."""
 
         if not self.trip_data:
-            return np.NaN
+            return np.nan
 
         return np.max(self.deck_space_utilizations)
 
@@ -482,7 +482,7 @@ class Vessel(Agent):
         """Returns minimum deck_space utilization."""
 
         if not self.trip_data:
-            return np.NaN
+            return np.nan
 
         return np.min(self.deck_space_utilizations)
 
@@ -491,7 +491,7 @@ class Vessel(Agent):
         """Returns mean deck space utilization."""
 
         if not self.trip_data:
-            return np.NaN
+            return np.nan
 
         return np.mean(self.deck_space_utilizations)
 
@@ -500,7 +500,7 @@ class Vessel(Agent):
         """Returns median deck space utilization."""
 
         if not self.trip_data:
-            return np.NaN
+            return np.nan
 
         return np.median(self.deck_space_utilizations)
 
@@ -509,7 +509,7 @@ class Vessel(Agent):
         """Returns items corresponding to `self.max_cargo_mass`."""
 
         if not self.trip_data:
-            return np.NaN
+            return np.nan
 
         i = np.argmax(self.cargo_mass_list)
         return self.trip_data[i].items
@@ -519,7 +519,7 @@ class Vessel(Agent):
         """Returns items corresponding to `self.min_cargo_mass`."""
 
         if not self.trip_data:
-            return np.NaN
+            return np.nan
 
         i = np.argmin(self.cargo_mass_list)
         return self.trip_data[i].items
@@ -529,7 +529,7 @@ class Vessel(Agent):
         """Returns items corresponding to `self.max_deck_space`."""
 
         if not self.trip_data:
-            return np.NaN
+            return np.nan
 
         i = np.argmax(self.deck_space_list)
         return self.trip_data[i].items
@@ -539,7 +539,7 @@ class Vessel(Agent):
         """Returns items corresponding to `self.min_deck_space`."""
 
         if not self.trip_data:
-            return np.NaN
+            return np.nan
 
         i = np.argmin(self.deck_space_list)
         return self.trip_data[i].items

--- a/wisdem/orbit/parametric.py
+++ b/wisdem/orbit/parametric.py
@@ -149,7 +149,7 @@ class ParametricManager:
                 )
 
             except AttributeError:
-                res = np.NaN
+                res = np.nan
 
             results[k] = res
 


### PR DESCRIPTION
## Purpose
Our pip installs seem to have updated to using numpy 2.0, which does not use `np.NaN`.  This PR is moving them to `np.nan`.

First, I'd like to see if it fails over here on WISDEM.

Here is an example of a pip install failing on ROSCO: https://github.com/NREL/ROSCO/actions/runs/11163512186/job/31030654634?pr=368

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
