### PR TITLE
Fix bos capex bug

### DIFF
--- a/examples/13_design_of_experiments/analysis_options.yaml
+++ b/examples/13_design_of_experiments/analysis_options.yaml
@@ -153,5 +153,5 @@ driver:
     num_samples: 5        # number of samples for (Uniform only)
 
 recorder:
-    flag: False              # Flag to activate OpenMDAO recorder
+    flag: True              # Flag to activate OpenMDAO recorder
     file_name: log_opt.sql  # Name of OpenMDAO recorder

--- a/examples/13_design_of_experiments/analysis_options.yaml
+++ b/examples/13_design_of_experiments/analysis_options.yaml
@@ -153,5 +153,5 @@ driver:
     num_samples: 5        # number of samples for (Uniform only)
 
 recorder:
-    flag: True              # Flag to activate OpenMDAO recorder
+    flag: False             # Flag to activate OpenMDAO recorder
     file_name: log_opt.sql  # Name of OpenMDAO recorder

--- a/wisdem/orbit/api/wisdem.py
+++ b/wisdem/orbit/api/wisdem.py
@@ -767,7 +767,7 @@ class OrbitWisdem(om.ExplicitComponent):
         project = ProjectManager(config)
         project.run()
 
-        capacity_kW = 1e3 * float(inputs["turbine_rating"][0]) * int(discrete_inputs["number_of_turbines"]),
+        capacity_kW = 1e3 * inputs["turbine_rating"] * discrete_inputs["number_of_turbines"]
         outputs["bos_capex"] = project.bos_capex
         outputs["soft_capex"] = project.soft_capex
         outputs["project_capex"] = project.project_capex

--- a/wisdem/orbit/api/wisdem.py
+++ b/wisdem/orbit/api/wisdem.py
@@ -767,6 +767,8 @@ class OrbitWisdem(om.ExplicitComponent):
         project = ProjectManager(config)
         project.run()
 
+        # The ORBIT version of total_capex includes turbine capex, so we do our own sum of
+        # the parts here that wisdem doesn't account for
         capacity_kW = 1e3 * inputs["turbine_rating"] * discrete_inputs["number_of_turbines"]
         outputs["bos_capex"] = project.bos_capex
         outputs["soft_capex"] = project.soft_capex

--- a/wisdem/orbit/api/wisdem.py
+++ b/wisdem/orbit/api/wisdem.py
@@ -458,19 +458,33 @@ class OrbitWisdem(om.ExplicitComponent):
             "bos_capex",
             0.0,
             units="USD",
-            desc="Total BOS CAPEX not including commissioning or decommissioning.",  # noqa: E501
+            desc="Sum of system and installation capex",
+        )
+        self.add_output(
+            "soft_capex",
+            0.0,
+            units="USD",
+            desc="Project costs associated with commissioning, decommissioning and financing",
+        )
+        self.add_output(
+            "project_capex",
+            0.0,
+            units="USD",
+            desc="costs associated with the lease area, "+
+            "the development of the construction operations plan,"+
+            "and any environmental review and other upfront project costs."
         )
         self.add_output(
             "total_capex",
             0.0,
             units="USD",
-            desc="Total BOS CAPEX including commissioning and decommissioning.",  # noqa: E501
+            desc="Total capex of bos + soft + project",
         )
         self.add_output(
             "total_capex_kW",
             0.0,
             units="USD/kW",
-            desc="Total BOS CAPEX including commissioning and decommissioning.",  # noqa: E501
+            desc="Total capex of bos + soft + project per rated project capacity in kW",
         )
         self.add_output(
             "installation_time",
@@ -753,8 +767,11 @@ class OrbitWisdem(om.ExplicitComponent):
         project = ProjectManager(config)
         project.run()
 
+        capacity_kW = 1e3 * float(inputs["turbine_rating"][0]) * int(discrete_inputs["number_of_turbines"]),
         outputs["bos_capex"] = project.bos_capex
-        outputs["total_capex"] = project.total_capex
-        outputs["total_capex_kW"] = project.total_capex_per_kw
+        outputs["soft_capex"] = project.soft_capex
+        outputs["project_capex"] = project.project_capex
+        outputs["total_capex"] = project.bos_capex + project.soft_capex + project.project_capex
+        outputs["total_capex_kW"] = outputs["total_capex"] / capacity_kW
         outputs["installation_time"] = project.installation_time
         outputs["installation_capex"] = project.installation_capex

--- a/wisdem/test/test_gluecode/test_gc_modified_yaml.py
+++ b/wisdem/test/test_gluecode/test_gc_modified_yaml.py
@@ -29,7 +29,7 @@ class TestRegression(unittest.TestCase):
 
         self.assertAlmostEqual(wt_opt["rotorse.blade_mass"][0], 68208.64259481194, 1) # new value: improved interpolation
         self.assertAlmostEqual(wt_opt["rotorse.rp.AEP"][0] * 1.0e-6, 78.1779174347384, 1)
-        self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 84.44377900634504, 1)
+        self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 71.17844382182804, 1)
         self.assertAlmostEqual(wt_opt["rotorse.rs.tip_pos.tip_deflection"][0], 25.831844078972203, 1)
         self.assertAlmostEqual(wt_opt["towerse.z_param"][-1], 144.386, 3)
 

--- a/wisdem/test/test_gluecode/test_gc_yaml_floating.py
+++ b/wisdem/test/test_gluecode/test_gc_yaml_floating.py
@@ -27,7 +27,7 @@ class TestRegression(unittest.TestCase):
 
         self.assertAlmostEqual(wt_opt["rotorse.rp.AEP"][0] * 1.0e-6, 77.90375792369237, 1)
         self.assertAlmostEqual(wt_opt["rotorse.blade_mass"][0], 68208.64259481194, 1) # new value: improved interpolation
-        self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 95.31566565816442, 1)
+        self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 80.80374468556248, 1)
         self.assertAlmostEqual(wt_opt["rotorse.rs.tip_pos.tip_deflection"][0], 25.831844078972203, 1)
 
 

--- a/wisdem/test/test_gluecode/test_gluecode.py
+++ b/wisdem/test/test_gluecode/test_gluecode.py
@@ -39,7 +39,7 @@ class TestRegression(unittest.TestCase):
         self.assertAlmostEqual(
             wt_opt["rotorse.blade_mass"][0], 68208.64259481194, 1
         )  # new value: improved interpolation
-        self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 82.92352084553283, 1)
+        self.assertAlmostEqual(wt_opt["financese.lcoe"][0] * 1.0e3, 69.61150219111778, 1)
         self.assertAlmostEqual(wt_opt["rotorse.rs.tip_pos.tip_deflection"][0], 25.831844078972203, 1)
         self.assertAlmostEqual(wt_opt["towerse.z_param"][-1], 144.386, 3)
 


### PR DESCRIPTION
## Purpose
Thanks to a Forum [post](https://forums.nrel.gov/t/lcoe-optimization-and-bos-cost/7712/10), we realized that turbine capex was being double counted since it was [also included](https://github.com/WISDEM/ORBIT/blob/dev/ORBIT/manager.py#L1814) in the ORBIT "total_capex" value after the ORBIT overhaul.  This fixes that error.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
