### PR TITLE
generate K and I matrices from precomp in windio v1.0 format

### DIFF
--- a/.github/workflows/Publish_WISDEM.yml
+++ b/.github/workflows/Publish_WISDEM.yml
@@ -52,14 +52,6 @@ jobs:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}
 
-      - name: Build wheels mac-12
-        if: contains( matrix.os, 'macos-12')
-        uses: pypa/cibuildwheel@v2.22.0
-        env:
-          CC: ${{ steps.install_cc.outputs.cc }}
-          CXX: ${{ steps.install_cc.outputs.cxx }}
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="12.0"
-
       - name: Build wheels mac-13
         if: contains( matrix.os, 'macos-13')
         uses: pypa/cibuildwheel@v2.22.0
@@ -75,6 +67,14 @@ jobs:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="14.0"
+
+      - name: Build wheels mac-15
+        if: contains( matrix.os, 'macos-15')
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CC: ${{ steps.install_cc.outputs.cc }}
+          CXX: ${{ steps.install_cc.outputs.cxx }}
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="15.0"
 
       - name: Build wheels windows
         if: contains( matrix.os, 'windows')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wisdem"
-version = "3.20.0"
+version = "3.20.1"
 description = "Wind-Plant Integrated System Design & Engineering Model"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [  # Optional
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: C",
   "Programming Language :: Fortran",
@@ -120,7 +121,7 @@ namespaces = true
 
 [tool.black]
 line-length = 120
-target-version = ['py39']
+target-version = ['py313']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/wisdem/floatingse/floating_system.py
+++ b/wisdem/floatingse/floating_system.py
@@ -538,6 +538,10 @@ class FloatingSystem(om.Group):
 
     def setup(self):
         opt = self.options["modeling_options"]
+        n_member = opt["floating"]["members"]["n_members"]
 
         self.add_subsystem("plat", PlatformFrame(options=opt), promotes=["*"])
         self.add_subsystem("mux", PlatformTurbineSystem(options=opt), promotes=["*"])
+
+        for k in range(n_member):
+            self.set_input_defaults(f"member{k}:nodes_xyz", val=NULL * np.ones((MEMMAX, 3)), units="m")

--- a/wisdem/glue_code/gc_LoadInputs.py
+++ b/wisdem/glue_code/gc_LoadInputs.py
@@ -1038,10 +1038,18 @@ class WindTurbineOntologyPython(object):
             K = []
             for i in range(self.modeling_options["WISDEM"]["RotorSE"]["n_span"]):
                 Ki = np.zeros(21)
-                Ki[11] = wt_opt["rotorse.EA"][i]
-                Ki[15] = wt_opt["rotorse.EIxx"][i]
-                Ki[18] = wt_opt["rotorse.EIyy"][i]
-                Ki[20] = wt_opt["rotorse.GJ"][i]
+                Ki[0] = wt_opt["rotorse.re.generate_KI.K"][i,0,0]
+                Ki[6] = wt_opt["rotorse.re.generate_KI.K"][i,1,1]
+                Ki[11] = wt_opt["rotorse.re.generate_KI.K"][i,2,2]
+                Ki[12] = wt_opt["rotorse.re.generate_KI.K"][i,2,3]
+                Ki[13] = wt_opt["rotorse.re.generate_KI.K"][i,2,4]
+                Ki[14] = wt_opt["rotorse.re.generate_KI.K"][i,2,5]
+                Ki[15] = wt_opt["rotorse.re.generate_KI.K"][i,3,3]
+                Ki[16] = wt_opt["rotorse.re.generate_KI.K"][i,3,4]
+                Ki[17] = wt_opt["rotorse.re.generate_KI.K"][i,3,5]
+                Ki[18] = wt_opt["rotorse.re.generate_KI.K"][i,4,4]
+                Ki[19] = wt_opt["rotorse.re.generate_KI.K"][i,4,5]
+                Ki[20] = wt_opt["rotorse.re.generate_KI.K"][i,5,5]
                 K.append(Ki.tolist())
             self.wt_init["components"]["blade"]["elastic_properties_mb"]["six_x_six"]["stiff_matrix"]["values"] = K
             self.wt_init["components"]["blade"]["elastic_properties_mb"]["six_x_six"]["inertia_matrix"] = {}
@@ -1051,17 +1059,17 @@ class WindTurbineOntologyPython(object):
             I = []
             for i in range(self.modeling_options["WISDEM"]["RotorSE"]["n_span"]):
                 Ii = np.zeros(21)
-                Ii[0] = wt_opt["rotorse.rhoA"][i]
-                Ii[5] = -wt_opt["rotorse.rhoA"][i] * wt_opt["rotorse.re.y_cg"][i]
-                Ii[6] = wt_opt["rotorse.rhoA"][i]
-                Ii[10] = wt_opt["rotorse.rhoA"][i] * wt_opt["rotorse.re.x_cg"][i]
-                Ii[11] = wt_opt["rotorse.rhoA"][i]
-                Ii[12] = wt_opt["rotorse.rhoA"][i] * wt_opt["rotorse.re.y_cg"][i]
-                Ii[13] = -wt_opt["rotorse.rhoA"][i] * wt_opt["rotorse.re.x_cg"][i]
-                Ii[15] = wt_opt["rotorse.re.precomp.edge_iner"][i]
-                # Ii[16] = wt_opt["rotorse.re.precomp.edge_iner"][i]
-                Ii[18] = wt_opt["rotorse.re.precomp.flap_iner"][i]
-                Ii[20] = wt_opt["rotorse.rhoJ"][i]
+                Ii[0] = wt_opt["rotorse.re.generate_KI.I"][i,0,0]
+                Ii[5] = wt_opt["rotorse.re.generate_KI.I"][i,0,5]
+                Ii[6] = wt_opt["rotorse.re.generate_KI.I"][i,1,1]
+                Ii[10] = wt_opt["rotorse.re.generate_KI.I"][i,1,5]
+                Ii[11] = wt_opt["rotorse.re.generate_KI.I"][i,2,2]
+                Ii[12] = wt_opt["rotorse.re.generate_KI.I"][i,2,3]
+                Ii[13] = wt_opt["rotorse.re.generate_KI.I"][i,2,4]
+                Ii[15] = wt_opt["rotorse.re.generate_KI.I"][i,3,3]
+                Ii[16] = wt_opt["rotorse.re.generate_KI.I"][i,3,4]
+                Ii[18] = wt_opt["rotorse.re.generate_KI.I"][i,4,4]
+                Ii[20] = wt_opt["rotorse.re.generate_KI.I"][i,5,5]
                 I.append(Ii.tolist())
             self.wt_init["components"]["blade"]["elastic_properties_mb"]["six_x_six"]["inertia_matrix"]["values"] = I
 

--- a/wisdem/precomp/precomp_to_beamdyn.py
+++ b/wisdem/precomp/precomp_to_beamdyn.py
@@ -32,7 +32,7 @@ class TransformCrossSectionMatrix(object):
         M3 = R @ M2 @ R.T
         return M3
 
-def pc2bd_K(EA, EIxx, EIyy, EIxy, EA_EIxx, EA_EIyy, EIxx_GJ, EIyy_GJ, EA_GJ, GJ, rhoJ, edge_iner, flap_iner, x_sc, y_sc, kxs = 1., kys = 0.6):
+def pc2bd_K(EA, EIxx, EIyy, EIxy, EA_EIxx, EA_EIyy, EIxx_GJ, EIyy_GJ, EA_GJ, GJ, rhoJ, edge_iner, flap_iner, x_tc, y_tc, kxs = 1., kys = 0.6):
     """
     Given PreComp cross-sectional stiffness inputs, 
     returns 6x6 stiffness matrix at the x=0 y=0
@@ -60,8 +60,8 @@ def pc2bd_K(EA, EIxx, EIyy, EIxy, EA_EIxx, EA_EIyy, EIxx_GJ, EIyy_GJ, EA_GJ, GJ,
         - GJ: torsional stiffness
         - rhoJ: polar moment of inertia, used to estimate shear stiffness terms
         - A: cross sectional area, used to estimate shear stiffness terms
-        - x_sc: x coordinate of shear center
-        - y_sc: y coordinate of shear center
+        - x_tc: x coordinate of tension (elastic) center
+        - y_tc: y coordinate of tension (elastic) center
         - kxs: stiffness shear along x (default = 1.)
         - kys: stiffness shear along y (default = 0.6)
     """
@@ -85,7 +85,7 @@ def pc2bd_K(EA, EIxx, EIyy, EIxy, EA_EIxx, EA_EIyy, EIxx_GJ, EIyy_GJ, EA_GJ, GJ,
     
     # Translate matrix back to origin
     transform = TransformCrossSectionMatrix()
-    T = transform.CrossSectionTranslationMatrix(-x_sc, -y_sc)
+    T = transform.CrossSectionTranslationMatrix(-x_tc, -y_tc)
     K_ref = T.T @ K_sc @ T 
 
     return K_ref

--- a/wisdem/rotorse/rotor_elasticity.py
+++ b/wisdem/rotorse/rotor_elasticity.py
@@ -8,7 +8,7 @@ from wisdem.precomp import PreComp, Profile, CompositeSection, Orthotropic2DMate
 from wisdem.commonse.utilities import rotate, arc_length
 import logging
 logger = logging.getLogger("wisdem/weis")
-
+from wisdem.precomp.precomp_to_beamdyn import pc2bd_K, pc2bd_I
 
 class RunPreComp(ExplicitComponent):
     # Openmdao component to run precomp and generate the elastic properties of a wind turbine blade
@@ -864,6 +864,208 @@ class RunPreComp(ExplicitComponent):
         outputs["mass_all_blades"] = mass_all_blades
         outputs["I_all_blades"] = I_all_blades
 
+class generate_KI(ExplicitComponent):
+
+    def initialize(self):
+        self.options.declare('modeling_options')
+
+    def setup(self):
+        
+        modopt = self.options['modeling_options']
+        rotorse_options  = modopt['WISDEM']['RotorSE']
+        self.n_span = n_span = rotorse_options['n_span']
+
+        self.add_input(
+            "EA", 
+            val=np.zeros(n_span), 
+            units="N", 
+            desc="Axial stiffness at the elastic center, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "EIxx",
+            val=np.zeros(n_span),
+            units="N*m**2",
+            desc="Section lag (edgewise) bending stiffness about the XE axis, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input("EIyy",
+            val=np.zeros(n_span),
+            units="N*m**2",
+            desc="Section flap bending stiffness about the YE axis, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "EIxy", 
+            val=np.zeros(n_span), 
+            units="N*m**2", 
+            desc="Coupled flap-lag stiffness with respect to the XE-YE frame, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "EA_EIxx", 
+            val=np.zeros(n_span), 
+            units="N*m", 
+            desc="Coupled axial-lag stiffness with respect to the XE-YE frame, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "EA_EIyy", 
+            val=np.zeros(n_span), 
+            units="N*m", 
+            desc="Coupled axial-flap stiffness with respect to the XE-YE frame, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "EIxx_GJ", 
+            val=np.zeros(n_span), 
+            units="N*m**2", 
+            desc="Coupled lag-torsion stiffness with respect to the XE-YE frame, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "EIyy_GJ", 
+            val=np.zeros(n_span), 
+            units="N*m**2", 
+            desc="Coupled flap-torsion stiffness with respect to the XE-YE frame, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "EA_GJ", 
+            val=np.zeros(n_span), 
+            units="N*m", 
+            desc="Coupled axial-torsion stiffness with respect to the XE-YE frame, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "GJ",
+            val=np.zeros(n_span),
+            units="N*m**2",
+            desc="Section torsion stiffness at the elastic center, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "rhoA", 
+            val=np.zeros(n_span), 
+            units="kg/m", 
+            desc="Section mass per unit length, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "rhoJ", 
+            val=np.zeros(n_span), 
+            units="kg*m", 
+            desc="polar mass moment of inertia per unit length, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "Tw_iner",
+            val=np.zeros(n_span),
+            units="deg",
+            desc="Orientation of the section principal inertia axes with respect the blade reference plane, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "x_tc",
+            val=np.zeros(n_span),
+            units="m",
+            desc="X-coordinate of the tension-center offset with respect to the XR-YR axes, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "y_tc",
+            val=np.zeros(n_span),
+            units="m",
+            desc="Chordwise offset of the section tension-center with respect to the XR-YR axes, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "x_cg",
+            val=np.zeros(n_span),
+            units="m",
+            desc="X-coordinate of the center-of-mass offset with respect to the XR-YR axes, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "y_cg",
+            val=np.zeros(n_span),
+            units="m",
+            desc="Chordwise offset of the section center of mass with respect to the XR-YR axes, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "flap_iner",
+            val=np.zeros(n_span),
+            units="kg/m",
+            desc="Section flap inertia about the Y_G axis per unit length, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "edge_iner",
+            val=np.zeros(n_span),
+            units="kg/m",
+            desc="Section lag inertia about the X_G axis per unit length, using the convention of WISDEM solver PreComp.",
+        )
+        self.add_input(
+            "theta",
+            val=np.zeros(n_span),
+            units="deg",
+            desc="Aerodynamic twist angle at each section (positive decreases angle of attack)",
+        )
+
+        # Outputs are 6x6 K and I matrices at the center of the windIO reference axes
+        self.add_output(
+            "K",
+            val=np.zeros((n_span,6,6)), 
+            desc="Stiffness matrix at the center of the windIO reference axes."
+        )
+        self.add_output(
+            "I",
+            val=np.zeros((n_span,6,6)), 
+            desc="Inertia matrix at the center of the windIO reference axes."
+        )
+
+    def compute(self, inputs, outputs):
+
+        # Initialize empty 6x6 K and I matrices
+        K = np.zeros((self.n_span,6,6))
+        I = np.zeros((self.n_span,6,6))
+        EA = inputs["EA"]
+        EIxx = inputs["EIxx"]
+        EIyy = inputs["EIyy"]
+        EIxy = inputs["EIxy"]
+        GJ = inputs["GJ"]
+        EA_EIxx = inputs["EA_EIxx"]
+        EA_EIyy = inputs["EA_EIyy"]
+        EIxx_GJ = inputs["EIxx_GJ"]
+        EIyy_GJ = inputs["EIyy_GJ"]
+        EA_GJ = inputs["EA_GJ"]
+        rhoA = inputs["rhoA"]
+        rhoJ = inputs["rhoJ"]
+        Tw_iner = np.deg2rad(inputs["Tw_iner"])
+        x_cg = inputs["x_cg"]
+        y_cg = inputs["y_cg"]
+        x_tc = inputs["x_tc"]
+        y_tc = inputs["y_tc"]
+        edge_iner = inputs["edge_iner"]
+        flap_iner = inputs["flap_iner"]
+        aero_twist =  np.deg2rad(inputs["theta"])
+
+        for i in range(self.n_span):
+            # Build stiffness matrix at the reference axis
+            K[i,:,:] = pc2bd_K(
+                EA[i],
+                EIxx[i],
+                EIyy[i],
+                EIxy[i],
+                EA_EIxx[i],
+                EA_EIyy[i],
+                EIxx_GJ[i],
+                EIyy_GJ[i],
+                EA_GJ[i],
+                GJ[i],
+                rhoJ[i],
+                edge_iner[i],
+                flap_iner[i],
+                x_tc[i],
+                y_tc[i],
+                )
+            # Build inertia matrix at the reference axis
+            I[i,:,:] = pc2bd_I(
+                rhoA[i],
+                edge_iner[i],
+                flap_iner[i],
+                rhoJ[i],
+                x_cg[i],
+                y_cg[i],
+                Tw_iner[i],
+                aero_twist[i],
+                )
+        
+        outputs["K"] = K
+        outputs["I"] = I
 
 class RotorElasticity(Group):
     # OpenMDAO group to compute the blade elastic properties and natural frequencies
@@ -877,20 +1079,26 @@ class RotorElasticity(Group):
 
         # Get elastic properties by running precomp
         promote_list = [
-            "chord",
-            "theta",
-            "A",
             "EA",
             "EIxx",
             "EIyy",
             "EIxy",
             "GJ",       
+            "EA_EIxx",
+            "EA_EIyy",
+            "EIxx_GJ",
+            "EIyy_GJ",
+            "EA_GJ",
             "rhoA",
             "rhoJ",
-            "x_sc",
-            "y_sc",
-            "pitch_axis",
-            "coord_xy_interp",
+            "Tw_iner",
+            "x_tc",
+            "y_tc",
+            "x_cg",
+            "y_cg",
+            "edge_iner",
+            "flap_iner",
+            "theta",
         ]
         self.add_subsystem(
             "precomp",
@@ -898,13 +1106,12 @@ class RotorElasticity(Group):
             promotes=promote_list
             + [
                 "r",
-                "Tw_iner",
+                "chord",
+                "A",
                 "precurve",
                 "presweep",
-                "x_tc",
-                "y_tc",
-                "x_cg",
-                "y_cg",
+                "pitch_axis",
+                "coord_xy_interp",
                 "sc_ss_mats",
                 "sc_ps_mats",
                 "te_ss_mats",
@@ -923,4 +1130,10 @@ class RotorElasticity(Group):
                 "mass_all_blades",
                 "I_all_blades",
             ],
+        )
+
+        self.add_subsystem(
+            "generate_KI",
+            generate_KI(modeling_options=modeling_options),
+            promotes=promote_list,
         )


### PR DESCRIPTION
## Purpose
WEIS Issue [#365](https://github.com/WISDEM/WEIS/issues/365) correctly pointed out that the output yaml file was still reporting the raw properties from PreComp, not respecting the windIO v1.0 format. I've then moved the handling of the elastic properties from WEIS to WISDEM. I will need to go back and update things once windIO v2.0 is released, but that will take a few more weeks, so I think we can start merging this and tag a minor release v3.20.1.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
