### PR TITLE
ensuring that nrefine is a user option for both tower and monopile

### DIFF
--- a/wisdem/commonse/cylinder_member.py
+++ b/wisdem/commonse/cylinder_member.py
@@ -17,7 +17,7 @@ from wisdem.commonse.akima import Akima
 
 NULL = -9999
 MEMMAX = 200
-NREFINE = 1
+NREFINE_DEFAULT = 1
 
 # For rectangular
 # This assumes that the Ca only depends on the aspect ratio
@@ -138,7 +138,7 @@ class RectCrossSection(CrossSection):
         self.b = make_float(self.b)
 
 
-def get_nfull(npts, nref=NREFINE):
+def get_nfull(npts, nref=NREFINE_DEFAULT):
     n_full = int(1 + nref * (npts - 1))
     return n_full
 
@@ -609,7 +609,7 @@ class MemberDiscretization(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare("n_height")
-        self.options.declare("n_refine", default=NREFINE)
+        self.options.declare("n_refine", default=NREFINE_DEFAULT)
         self.options.declare("member_shape_variables")
 
     def setup(self):
@@ -1118,7 +1118,7 @@ class MemberComplex(om.ExplicitComponent):
     def initialize(self):
         self.options.declare("options")
         self.options.declare("idx")
-        self.options.declare("n_refine", default=NREFINE)
+        self.options.declare("n_refine", default=NREFINE_DEFAULT)
 
     def setup(self):
         opt = self.options["options"]

--- a/wisdem/towerse/tower.py
+++ b/wisdem/towerse/tower.py
@@ -7,8 +7,6 @@ import wisdem.commonse.cylinder_member as mem
 from wisdem.commonse import NFREQ, gravity
 
 RIGID = 1e30
-NREFINE = 3
-
 
 class PreDiscretization(om.ExplicitComponent):
     """


### PR DESCRIPTION
## Purpose
Fixes the bug identified in the [forums](https://forums.nrel.gov/t/is-the-wisdem-n-refine-parameter-settable-for-the-monopile/8535/4).

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
