### PR TITLE
Handling cases when MPF and mode shapes have mismatch

### DIFF
--- a/wisdem/commonse/utilities.py
+++ b/wisdem/commonse/utilities.py
@@ -106,16 +106,21 @@ def get_xyz_mode_shapes(r, freqs, xdsp, ydsp, zdsp, xmpf, ympf, zmpf, idx0=None,
         np.max(np.abs(xdsp[m, :])),
         np.max(np.abs(ydsp[m, :])),
         np.max(np.abs(zdsp[m, :]) * 1e-7 ) # supressing Z
-    ]
-        idir_disp = np.argmax(max_disp)
-        idir_mpf = idir[m]
+        ]
 
-        # Verification: If MPF and displacement directions disagree, use displacement and warn
-        if idir_disp != idir_mpf:
-            logger.warning(f"Mode {m} (freq={freqs[m]:.3f}): MPF direction ({idir_mpf}) disagrees with max displacement direction ({idir_disp}). Using displacement direction.")
-            idir_use = idir_disp
+        displacements_threshold = 1e-7
+        if max(max_disp) < displacements_threshold:
+            logger.debug(f"Mode {m}: All displacements negligible ({max(max_disp):.2e}), using MPF direction.")
+            idir_use = idir[m]
         else:
-            idir_use = idir_mpf
+            idir_disp = np.argmax(max_disp)
+            idir_mpf = idir[m]
+            # Verification: If MPF and displacement directions disagree, use displacement and warn
+            if idir_disp != idir_mpf:
+                logger.warning(f"Mode {m} (freq={freqs[m]:.3f}): MPF direction ({idir_mpf}) disagrees with max displacement direction ({idir_disp}). Using displacement direction.")
+                idir_use = idir_disp
+            else:
+                idir_use = idir_mpf
 
         if idir_use == 0: # idir[m] == 0:
             if expect_all and ix >= nfreq2:

--- a/wisdem/commonse/utilities.py
+++ b/wisdem/commonse/utilities.py
@@ -101,7 +101,23 @@ def get_xyz_mode_shapes(r, freqs, xdsp, ydsp, zdsp, xmpf, ympf, zmpf, idx0=None,
         if np.isnan(freqs[m]) or (freqs[m] < 1e-1) or (mpfs_ratio[m] < 1e3) or (mpfs[m, :].max() < 1e-13):
             continue
         
-        if idir[m] == 0:
+        # Handle cases where mpf's dont agree with the raw mode shape (x,y,zdsp)
+        max_disp = [
+        np.max(np.abs(xdsp[m, :])),
+        np.max(np.abs(ydsp[m, :])),
+        np.max(np.abs(zdsp[m, :]) * 1e-7 ) # supressing Z
+    ]
+        idir_disp = np.argmax(max_disp)
+        idir_mpf = idir[m]
+
+        # Verification: If MPF and displacement directions disagree, use displacement and warn
+        if idir_disp != idir_mpf:
+            logger.warning(f"Mode {m} (freq={freqs[m]:.3f}): MPF direction ({idir_mpf}) disagrees with max displacement direction ({idir_disp}). Using displacement direction.")
+            idir_use = idir_disp
+        else:
+            idir_use = idir_mpf
+
+        if idir_use == 0: # idir[m] == 0:
             if expect_all and ix >= nfreq2:
                 continue
             imode = xroot1[m]
@@ -113,7 +129,7 @@ def get_xyz_mode_shapes(r, freqs, xdsp, ydsp, zdsp, xmpf, ympf, zmpf, idx0=None,
             mshapes_x[ix, :] = xpolys[m, :]
             freq_x[ix] = freqs[m]
             ix += 1
-        elif idir[m] == 1:
+        elif idir_use == 1: # idir[m] == 1:
             if expect_all and iy >= nfreq2:
                 continue
             imode = yroot1[m]
@@ -125,7 +141,7 @@ def get_xyz_mode_shapes(r, freqs, xdsp, ydsp, zdsp, xmpf, ympf, zmpf, idx0=None,
             mshapes_y[iy, :] = ypolys[m, :]
             freq_y[iy] = freqs[m]
             iy += 1
-        elif idir[m] == 2:
+        elif idir_use == 2: # idir[m] == 2:
             if expect_all and iz >= nfreq2:
                 continue
             # Torsional modes are not well captured by Frame3DD


### PR DESCRIPTION

## Purpose
[//]: # (Explain the goal of this pull request. If it addresses an existing issue be sure to link to it. Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal. If it accomplishes multiple goals, it may be best to create separate PR's for each.)

Under certain conditions (observed only in floating towers), the Modal Participation Factor (MPF) provided by pyFrame3DD does not match the actual mode shape. This causes mischaracterization when sorting out the modes shapes, resulting in ElastoDyn tower mode shapes having `nan`'s (we get a zero/sum(zero) condition), causing OpenFAST to fail. Observed this when running floating optimizations for the WEIS workshop, multiple iterations fail to run OpenFAST due to the nan's in the tower mode shape. 

The proposed fix, checks if the MPF agrees with the abs(max(disp)) of the mode shape, if there is a disagreement, the classification falls back on using the mode shape, and warns the user through stdout.

### I've isolated a single iteration that fails to explain the fix:

The first plot shows the data (freq, MPF, and mode shapes) from pyframe3dd for the floating tower, modes 5-16. 

 - Modes 5, 6 are the last two ridged body modes. 
 - Mode 7, tower 1st side-2side, MPF agrees with mode shape.
 - Mode 8, tower 1st fore-aft, MPF agrees with mode shape.
 - Mode 9, possibly a Rx mode (disp at 1e-8), all three MPF's are very low.
 - ***Mode 10, tower 2nd side-2side per mode shape, but MPF indicates at tower fore-aft mode.***

<img width="1500" height="2000" alt="mode_shapes_plotInputData4get_xyz_mode_shapes" src="https://github.com/user-attachments/assets/3261270a-b1e4-4ed4-91d3-235fb5dd69ba" />


Using the fix, gives the below ElastoDyn tower mode shapes, for the failing iteration:

<img width="3600" height="3000" alt="tower_mode_shapes" src="https://github.com/user-attachments/assets/f7379598-5c2e-45f6-96fa-af3c74589d71" />

The WEIS optimization run with this fix, has not shown any failed iterations due to tower mode shape nan's

## Type of change
[//]: # (What types of change is it?)
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
[//]: # (Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.)

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation


@ptrbortolotti , @dzalkind 