### PR TITLE
drop support for python 3.9 and 3.10 due to wombat limits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "wisdem"
 version = "4.1.0"
 description = "Wind-Plant Integrated System Design & Engineering Model"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = {text = "Apache-2.0"}
 keywords = ["wind", "turbine", "mdao", "design", "optimization"]
 authors = [
@@ -33,8 +33,6 @@ classifiers = [  # Optional
   # that you indicate you support Python 3. These classifiers are *not*
   # checked by "pip install". See instead "python_requires" below.
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
## Purpose
Drop python 3.9 and 3.10 as they conflict with WOMBAT, see https://github.com/conda-forge/wisdem-feedstock/pull/95

## Type of change
<!-- What types of change is it?
_Select the appropriate type(s) that describe this PR_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- _Put an `x` in the boxes that apply._ -->

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
