### PR TITLE
Fix ambiguous rho_water default in MonopileSE

### DIFF
--- a/wisdem/fixed_bottomse/monopile.py
+++ b/wisdem/fixed_bottomse/monopile.py
@@ -1024,6 +1024,10 @@ class MonopileSE(om.Group):
     def setup(self):
         mod_opt = self.options["modeling_options"]["WISDEM"]["FixedBottomSE"]
 
+        # Resolve ambiguity: both prop and perf promote rho_water, but only
+        # perf's CylinderEnvironment sets a non-zero default (1025).
+        self.set_input_defaults("rho_water", 1025.0, units="kg/m**3")
+
         self.add_subsystem("prop", MonopileSEProp(modeling_options=self.options["modeling_options"]), promotes=["*"])
         self.add_subsystem("perf", MonopileSEPerf(modeling_options=self.options["modeling_options"]), promotes=["*"])
 


### PR DESCRIPTION
Hey,

I was trying to make it easier to install WISDEM on conda-forge, and while trying to create better recipes, I noticed some bugs. Are contributions to this repository welcome?

If so, I have a proposal for a bug fix:

## Problem
MonopileSE adds two sub-groups with promotes=["*"]:


```
self.add_subsystem("prop", MonopileSEProp(...), promotes=["*"])
self.add_subsystem("perf", MonopileSEPerf(...), promotes=["*"])
Both contain subsystems that declare rho_water as an input, but with conflicting defaults:
```

prop -> MemberStandard -> add_input("rho_water", 0.0) — uninitialized placeholder
perf -> MemberLoads -> CylinderEnvironment -> set_input_defaults("rho_water", 1025.0) — physically correct seawater density
When both are promoted to the top level, OpenMDAO sees two different defaults for the same name and raises:


The following inputs promoted to 'rho_water' have different values:
```
   perf.rho_water  [1025.]
   prop.rho_water  [0.]
```
This is a hard error in OpenMDAO since at least version 3.22.0 (changed from conditional_error to unconditional _collect_error). Since WISDEM requires openmdao >3.30, this error always triggers. It is documented behavior — the [OpenMDAO set_input_defaults documentation](https://openmdao.org/newdocs/versions/latest/features/core_features/running_your_models/set_input_defaults.html) describes this exact scenario and prescribes the fix.

## Affected tests

```
TestMonopileSE::testAddedMassForces
TestMonopileSE::testExampleRegression
TestMonopileSE::testProblemFixedPile
TestMonopileSE::testProblemFixedPile_GBF
```

## Fix
Set the default at the parent MonopileSE group level, as recommended by OpenMDAO:


In MonopileSE.setup():
`self.set_input_defaults("rho_water", 1025.0, units="kg/m**3")`
This gives both sub-groups a single authoritative default. The value 1025 kg/m³ is the standard seawater density — the physically meaningful value that CylinderEnvironment was already using.



## Type of change
<!-- What types of change is it?
_Select the appropriate type(s) that describe this PR_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
```
import openmdao.api as om

# Mimics the conflicting defaults in MonopileSE
class Inner1(om.ExplicitComponent):
    def setup(self):
        self.add_input("rho_water", 0.0, units="kg/m**3")
        self.add_output("y1", 0.0)

class Inner2(om.ExplicitComponent):
    def setup(self):
        self.add_input("rho_water", 0.0, units="kg/m**3")
        self.add_output("y2", 0.0)

class Sub1(om.Group):
    def setup(self):
        self.add_subsystem("c", Inner1(), promotes=["*"])

class Sub2(om.Group):
    def setup(self):
        self.add_subsystem("c", Inner2(), promotes=["*"])
        self.set_input_defaults("rho_water", 1025.0, units="kg/m**3")

class Parent(om.Group):
    def setup(self):
        self.add_subsystem("sub1", Sub1(), promotes=["*"])
        self.add_subsystem("sub2", Sub2(), promotes=["*"])

prob = om.Problem(model=Parent())
prob.setup()  # raises: inputs promoted to 'rho_water' have different values
Fix — add one line in Parent.setup():


class Parent(om.Group):
    def setup(self):
        self.add_subsystem("sub1", Sub1(), promotes=["*"])
        self.add_subsystem("sub2", Sub2(), promotes=["*"])
        self.set_input_defaults("rho_water", 1025.0, units="kg/m**3")
```

## Checklist
<!-- _Put an `x` in the boxes that apply._ -->

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
