### PR TITLE
Update yaml

### DIFF
--- a/examples/02_reference_turbines/IEA-10-198-RWT.yaml
+++ b/examples/02_reference_turbines/IEA-10-198-RWT.yaml
@@ -455,7 +455,7 @@ components:
                   start_nd_arc:
                       anchor:
                           name: DP02_DP00_triax
-                          handle: DP02_DP00_uniax
+                          handle: start_nd_arc
                   end_nd_arc:
                       anchor:
                           name: TE

--- a/examples/03_blade/analysis_options_aero.yaml
+++ b/examples/03_blade/analysis_options_aero.yaml
@@ -40,7 +40,7 @@ constraints:
     blade:
         stall:
             flag: False # Constraint on minimum stall margin
-            margin: 0.1 # Value of minimum stall margin in [rad]
+            margin: 5.0 # Value of minimum stall margin in [deg]
         chord:
             flag: True # Constraint max chord to its default value (4.75 m)
             max: 4.75 # Max chord value

--- a/examples/03_blade/analysis_options_aero.yaml
+++ b/examples/03_blade/analysis_options_aero.yaml
@@ -18,9 +18,9 @@ design_variables:
                 # corresponding to 'max_efficiency' or 'stall_margin'
                 n_opt: 8 # Number of control points along blade span. During inverse design, 
                 # twist is smoothened with a spline with these
-                # max_decrease: 0.08722222222222221 # Maximum decrease for the twist 
+                # max_decrease: 5 # Maximum decrease for the twist 
                 # in [rad] at the n_opt locations. Only used if flag is set to True
-                # max_increase: 0.08722222222222221 # Maximum increase for the twist 
+                # max_increase: 5 # Maximum increase for the twist 
                 # in [rad] at the n_opt locations. Only used if flag is set to True
                 # index_start: 2 # Lock the first two DVs from blade root
                 # index_end: 8 # All DVs close to blade tip are active

--- a/examples/03_blade/analysis_options_aerostruct.yaml
+++ b/examples/03_blade/analysis_options_aerostruct.yaml
@@ -13,8 +13,8 @@ design_variables:
                 flag: True             # Flag to optimize the twist
                 inverse: False         # Flag to determine twist from the user-defined desired margin to stall (defined in constraints)
                 n_opt: 4               # Number of control points along blade span
-                max_decrease: 0.08722222222222221 # Maximum decrease for the twist in [rad] at the n_opt locations
-                max_increase: 0.08722222222222221 # Maximum increase for the twist in [rad] at the n_opt locations
+                max_decrease: 5.0 # Maximum decrease for the twist in [deg] at the n_opt locations
+                max_increase: 5.0 # Maximum increase for the twist in [deg] at the n_opt locations
                 index_start: 2         # Lock the first two DVs from blade root
                 index_end: 4           # All DVs close to blade tip are active
             chord:
@@ -67,7 +67,7 @@ constraints:
             margin: 1.4175
         stall:
             flag: True    # Constraint on minimum stall margin
-            margin: 0.087 # Value of minimum stall margin in [rad]
+            margin: 5.0 # Value of minimum stall margin in [deg]
         moment_coefficient:
             flag: True    # Constraint on minimum stall margin
             max: 0.16

--- a/examples/03_blade/analysis_options_user.yaml
+++ b/examples/03_blade/analysis_options_user.yaml
@@ -9,8 +9,8 @@ design_variables:
                 flag: True  # Flag to optimize the twist
                 inverse: False # Flag to determine twist from the user-defined desired margin to stall (defined in constraints)
                 n_opt: 4     # Number of control points along blade span
-                max_decrease: 0.08722222222222221 # Maximum decrease for the twist in [rad] at the n_opt locations
-                max_increase: 0.08722222222222221 # Maximum increase for the twist in [rad] at the n_opt locations
+                max_decrease: 5.0 # Maximum decrease for the twist in [deg] at the n_opt locations
+                max_increase: 5.0 # Maximum increase for the twist in [deg] at the n_opt locations
                 index_start: 2 # Lock the first two DVs from blade root
                 index_end: 4 # All DVs close to blade tip are active
             chord:
@@ -42,7 +42,7 @@ constraints:
     blade:
         stall:
             flag: True     # Constraint on minimum stall margin
-            margin: 0.087 # Value of minimum stall margin in [rad]
+            margin: 5.0 # Value of minimum stall margin in [deg]
         chord:
             flag: False # Constraint max chord to its default value (4.75 m)
         root_circle_diameter:

--- a/examples/09_floating/analysis_options_mooropt.yaml
+++ b/examples/09_floating/analysis_options_mooropt.yaml
@@ -26,9 +26,9 @@ merit_figure: mooring_mass
 constraints:
     floating:
         operational_heel:
-            upper_bound: 0.08726646259971647 # 5 deg
+            upper_bound: 5.0
         survival_heel:
-            upper_bound: 0.17453292519943295 # 10 deg
+            upper_bound: 10.0
         max_surge:
             flag: false
             upper_bound: 0.1

--- a/examples/09_floating/analysis_options_semiopt.yaml
+++ b/examples/09_floating/analysis_options_semiopt.yaml
@@ -84,9 +84,9 @@ merit_figure: LCOE
 constraints:
     floating:
         operational_heel:
-            upper_bound: 0.08726646259971647 # 5 deg
+            upper_bound: 5.0
         survival_heel:
-            upper_bound: 0.17453292519943295 # 10 deg
+            upper_bound: 10.0
         max_surge:
             flag: false
             upper_bound: 0.1

--- a/examples/09_floating/analysis_options_sparopt.yaml
+++ b/examples/09_floating/analysis_options_sparopt.yaml
@@ -28,9 +28,9 @@ merit_figure: platform_mass
 constraints:
     floating:
         operational_heel:
-            upper_bound: 0.08726646259971647 # 5 deg
+            upper_bound: 5.0
         survival_heel:
-            upper_bound: 0.17453292519943295 # 10 deg
+            upper_bound: 10.0
         max_surge:
             flag: false
             upper_bound: 0.1

--- a/examples/13_design_of_experiments/analysis_options.yaml
+++ b/examples/13_design_of_experiments/analysis_options.yaml
@@ -8,8 +8,8 @@ design_variables:
         flag: False  # Flag to optimize the twist
         inverse: False # Flag to determine twist from the user-defined desired margin to stall (defined in constraints)
         n_opt: 8     # Number of control points along blade span
-        max_decrease: 0.08722222222222221 # Maximum decrease for the twist in [rad] at the n_opt locations
-        max_increase: 0.08722222222222221 # Maximum increase for the twist in [rad] at the n_opt locations
+        max_decrease: 5.0 # Maximum decrease for the twist in [deg] at the n_opt locations
+        max_increase: 5.0 # Maximum increase for the twist in [deg] at the n_opt locations
       chord:
         flag: True     # Flag to optimize the chord
         n_opt: 8        # Number of control points along blade span

--- a/examples/16_inverse_design/analysis_options_rotor.yaml
+++ b/examples/16_inverse_design/analysis_options_rotor.yaml
@@ -9,8 +9,8 @@ design_variables:
             twist:
                 flag: True             # Flag to optimize the twist
                 n_opt: 4               # Number of control points along blade span
-                max_decrease: 0.08722222222222221 # Maximum decrease for the twist in [rad] at the n_opt locations
-                max_increase: 0.08722222222222221 # Maximum increase for the twist in [rad] at the n_opt locations
+                max_decrease: 5.0 # Maximum decrease for the twist in [deg] at the n_opt locations
+                max_increase: 5.0 # Maximum increase for the twist in [deg] at the n_opt locations
                 index_start: 2         # Lock the first two DVs from blade root
                 index_end: 4           # All DVs close to blade tip are active
             chord:
@@ -95,7 +95,7 @@ constraints:
             margin: 1.4175
         stall:
             flag: True    # Constraint on minimum stall margin
-            margin: 0.087 # Value of minimum stall margin in [rad]
+            margin: 5.0 # Value of minimum stall margin in [deg]
         moment_coefficient:
             flag: True    # Constraint on minimum stall margin
             max: 0.16

--- a/examples/18_rotor_tower_monopile/analysis_options.yaml
+++ b/examples/18_rotor_tower_monopile/analysis_options.yaml
@@ -9,8 +9,8 @@ design_variables:
                 flag: True             # Flag to optimize the twist
                 inverse: False         # Flag to determine twist from the user-defined desired margin to stall (defined in constraints)
                 n_opt: 6               # Number of control points along blade span
-                max_decrease: 0.08722222222222221 # Maximum decrease for the twist in [rad] at the n_opt locations
-                max_increase: 0.08722222222222221 # Maximum increase for the twist in [rad] at the n_opt locations
+                max_decrease: 5.0 # Maximum decrease for the twist in [deg] at the n_opt locations
+                max_increase: 5.0 # Maximum increase for the twist in [deg] at the n_opt locations
                 index_start: 1         # Lock the first DV at blade root
                 index_end: 5           # All DVs close to blade tip are active
             chord:
@@ -71,7 +71,7 @@ constraints:
             margin: 1.4175
         stall:
             flag: True    # Constraint on minimum stall margin
-            margin: 0.05233 # Value of minimum stall margin in [rad]
+            margin: 5.0 # Value of minimum stall margin in [deg]
         moment_coefficient:
             flag: True
             max: 0.16

--- a/examples/19_rotor_drivetrain_tower/analysis_options.yaml
+++ b/examples/19_rotor_drivetrain_tower/analysis_options.yaml
@@ -13,8 +13,8 @@ design_variables:
               flag: True 
               inverse: False
               n_opt: 8
-              max_decrease: 0.08722222222222223
-              max_increase: 0.08722222222222223
+              max_decrease: 5.0
+              max_increase: 5.0
               index_start: 2
               index_end: 8
           chord:
@@ -82,7 +82,7 @@ constraints:
   blade:
     stall:
       flag: True
-      margin: 0.05233
+      margin: 5.0
     chord:
       flag: True 
       max: 4.3

--- a/wisdem/ccblade/ccblade_component.py
+++ b/wisdem/ccblade/ccblade_component.py
@@ -498,7 +498,7 @@ class CCBladeTwist(ExplicitComponent):
             cd = np.zeros(self.n_span)
             alpha = np.zeros(self.n_span)
             Emax = np.zeros(self.n_span)
-            margin2stall = self.options["opt_options"]["constraints"]["blade"]["stall"]["margin"] * 180.0 / np.pi
+            margin2stall = self.options["opt_options"]["constraints"]["blade"]["stall"]["margin"]
             Re = np.array(Omega * inputs["r"] * inputs["chord"] * inputs["rho"][0] / inputs["mu"][0])
             aoa_op = inputs["aoa_op"]
             for i in range(self.n_span):

--- a/wisdem/ccblade/ccblade_component.py
+++ b/wisdem/ccblade/ccblade_component.py
@@ -538,7 +538,7 @@ class CCBladeTwist(ExplicitComponent):
 
             # Cap twist root region to 20 degrees
             for i in range(len(ccblade.theta)):
-                cap_twist_root = self.options["opt_options"]["design_variables"]["blade"]["aero_shape"]["twist"]["cap_twist_root"]
+                cap_twist_root = np.deg2rad(self.options["opt_options"]["design_variables"]["blade"]["aero_shape"]["twist"]["cap_twist_root"])
                 if ccblade.theta[-i - 1] > cap_twist_root:
                     ccblade.theta[0 : len(ccblade.theta) - i] = cap_twist_root
                     break

--- a/wisdem/glue_code/gc_LoadInputs.py
+++ b/wisdem/glue_code/gc_LoadInputs.py
@@ -866,6 +866,8 @@ class WindTurbineOntologyPython(object):
             if not self.modeling_options["user_elastic"]["blade"]:
                 # Webs positions TBD
                 # Structural layers
+                anchors = self.wt_init["components"]["blade"]["structure"]["anchors"]
+                n_anchors = len(anchors)
                 for i in range(self.modeling_options["WISDEM"]["RotorSE"]["n_layers"]):
                     self.wt_init["components"]["blade"]["structure"]["layers"][i]["thickness"]["grid"] = wt_opt[
                         "blade.outer_shape.s"
@@ -873,6 +875,60 @@ class WindTurbineOntologyPython(object):
                     self.wt_init["components"]["blade"]["structure"]["layers"][i]["thickness"]["values"] = wt_opt[
                         "blade.ps.layer_thickness_param"
                     ][i, :].tolist()
+                    # Update start_nd_arc for the anchor
+                    if "anchor" in self.wt_init["components"]["blade"]["structure"]["layers"][i]["start_nd_arc"]:
+                        anchor_name = self.wt_init["components"]["blade"]["structure"]["layers"][i]["start_nd_arc"]["anchor"]["name"]
+                        anchor_handle = self.wt_init["components"]["blade"]["structure"]["layers"][i]["start_nd_arc"]["anchor"]["handle"]
+                        for j in range(n_anchors):
+                            if anchors[j]["name"] == anchor_name:
+                                self.wt_init["components"]["blade"]["structure"]["anchors"][j][anchor_handle]["grid"] = wt_opt[
+                                    "blade.outer_shape.s"
+                                ].tolist()
+                                self.wt_init["components"]["blade"]["structure"]["anchors"][j][anchor_handle]["values"] = wt_opt[
+                                    "blade.structure.layer_start_nd"
+                                ][i, :].tolist()
+                                break
+                    # Update end_nd_arc for the anchor
+                    if "anchor" in self.wt_init["components"]["blade"]["structure"]["layers"][i]["end_nd_arc"]:
+                        anchor_name = self.wt_init["components"]["blade"]["structure"]["layers"][i]["end_nd_arc"]["anchor"]["name"]
+                        anchor_handle = self.wt_init["components"]["blade"]["structure"]["layers"][i]["end_nd_arc"]["anchor"]["handle"]
+                        for j in range(n_anchors):
+                            if anchors[j]["name"] == anchor_name:
+                                self.wt_init["components"]["blade"]["structure"]["anchors"][j][anchor_handle]["grid"] = wt_opt[
+                                    "blade.outer_shape.s"
+                                ].tolist()
+                                self.wt_init["components"]["blade"]["structure"]["anchors"][j][anchor_handle]["values"] = wt_opt[
+                                    "blade.structure.layer_end_nd"
+                                ][i, :].tolist()
+                                break
+                for i in range(self.modeling_options["WISDEM"]["RotorSE"]["n_webs"]):
+                    # Update start_nd_arc for the anchor
+                    if "anchor" in self.wt_init["components"]["blade"]["structure"]["webs"][i]["start_nd_arc"]:
+                        anchor_name = self.wt_init["components"]["blade"]["structure"]["webs"][i]["start_nd_arc"]["anchor"]["name"]
+                        anchor_handle = self.wt_init["components"]["blade"]["structure"]["webs"][i]["start_nd_arc"]["anchor"]["handle"]
+                        for j in range(n_anchors):
+                            if anchors[j]["name"] == anchor_name:
+                                self.wt_init["components"]["blade"]["structure"]["anchors"][j][anchor_handle]["grid"] = wt_opt[
+                                    "blade.outer_shape.s"
+                                ].tolist()
+                                self.wt_init["components"]["blade"]["structure"]["anchors"][j][anchor_handle]["values"] = wt_opt[
+                                    "blade.structure.web_start_nd"
+                                ][i, :].tolist()
+                                break
+                    # Update end_nd_arc for the anchor
+                    if "anchor" in self.wt_init["components"]["blade"]["structure"]["webs"][i]["end_nd_arc"]:
+                        anchor_name = self.wt_init["components"]["blade"]["structure"]["webs"][i]["end_nd_arc"]["anchor"]["name"]
+                        anchor_handle = self.wt_init["components"]["blade"]["structure"]["webs"][i]["end_nd_arc"]["anchor"]["handle"]
+                        for j in range(n_anchors):
+                            if anchors[j]["name"] == anchor_name:
+                                self.wt_init["components"]["blade"]["structure"]["anchors"][j][anchor_handle]["grid"] = wt_opt[
+                                    "blade.outer_shape.s"
+                                ].tolist()
+                                self.wt_init["components"]["blade"]["structure"]["anchors"][j][anchor_handle]["values"] = wt_opt[
+                                    "blade.structure.web_end_nd"
+                                ][i, :].tolist()
+                                break
+
 
             if "elastic_properties" not in self.wt_init["components"]["blade"]["structure"]:
                 self.wt_init["components"]["blade"]["structure"]["elastic_properties"] = {}

--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -1384,10 +1384,10 @@ class PoseOptimization(object):
             drive_constr = self.opt["constraints"]["drivetrain"]
 
             wt_opt["drivese.shaft_deflection_allowable"] = drive_constr["shaft_deflection"]["upper_bound"]
-            wt_opt["drivese.shaft_angle_allowable"] = drive_constr["shaft_angle"]["upper_bound"]
+            wt_opt["drivese.shaft_angle_allowable"] = np.deg2rad(drive_constr["shaft_angle"]["upper_bound"])
 
             wt_opt["drivese.stator_deflection_allowable"] = drive_constr["stator_deflection"]["upper_bound"]
-            wt_opt["drivese.stator_angle_allowable"] = drive_constr["stator_angle"]["upper_bound"]
+            wt_opt["drivese.stator_angle_allowable"] = np.deg2rad(drive_constr["stator_angle"]["upper_bound"])
 
             if self.modeling["WISDEM"]["DriveSE"]["direct"]:
                 wt_opt["drivese.access_diameter"] = drive_constr["access"]["lower_bound"]

--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -449,8 +449,8 @@ class PoseOptimization(object):
             wt_opt.model.add_design_var(
                 "blade.opt_var.twist_opt",
                 indices=indices_twist,
-                lower=init_twist_opt[indices_twist] - blade_opt["aero_shape"]["twist"]["max_decrease"],
-                upper=init_twist_opt[indices_twist] + blade_opt["aero_shape"]["twist"]["max_increase"],
+                lower=init_twist_opt[indices_twist] - np.deg2rad(blade_opt["aero_shape"]["twist"]["max_decrease"]),
+                upper=init_twist_opt[indices_twist] + np.deg2rad(blade_opt["aero_shape"]["twist"]["max_increase"]),
             )
 
         chord_options = blade_opt["aero_shape"]["chord"]
@@ -1376,7 +1376,7 @@ class PoseOptimization(object):
 
                     wt_opt["rotorse.rs.constr.max_strainU_te"] = blade_constr["strains_te_ss"]["max"]
                     wt_opt["rotorse.rs.constr.max_strainL_te"] = blade_constr["strains_te_ps"]["max"]
-                    wt_opt["rotorse.stall_check.stall_margin"] = blade_constr["stall"]["margin"] * 180.0 / np.pi
+                    wt_opt["rotorse.stall_check.stall_margin"] = blade_constr["stall"]["margin"]
                     if self.modeling["flags"]["tower"]:
                         wt_opt["tcons.max_allowable_td_ratio"] = blade_constr["tip_deflection"]["margin"]
 

--- a/wisdem/inputs/analysis_schema.yaml
+++ b/wisdem/inputs/analysis_schema.yaml
@@ -58,7 +58,7 @@ properties:
                             twist:
                                 type: object
                                 default: {}
-                                description: Blade twist as a design variable by adding or subtracting radians from the initial value at spline control points along the span.
+                                description: Blade twist as a design variable by adding or subtracting degrees from the initial value at spline control points along the span.
                                 properties:
                                     flag: *flag
                                     inverse:
@@ -78,13 +78,13 @@ properties:
                                     max_decrease:
                                         type: number
                                         description: Maximum allowable decrease of twist at each DV location along blade span.
-                                        default: 0.1
-                                        unit: rad
+                                        default: 5.0
+                                        unit: deg
                                     max_increase:
                                         type: number
                                         description: Maximum allowable increase of twist at each DV location along blade span.
-                                        default: 0.1
-                                        unit: rad
+                                        default: 5.0
+                                        unit: deg
                                     index_start: &index_start
                                         type: integer
                                         default: 0
@@ -100,8 +100,8 @@ properties:
                                     cap_twist_root:
                                         type: number
                                         description: Maximum allowable twist during an inverse design. Close to blade root, twist will be capped to this value.
-                                        default: 0.349
-                                        unit: rad
+                                        default: 20.0
+                                        unit: deg
                             chord:
                                 type: object
                                 default: {}
@@ -194,9 +194,9 @@ properties:
                             lower_bound: &angbound
                                 type: number
                                 minimum: 0.0
-                                maximum: 0.5235987756 # 30 deg
+                                maximum: 30.0
                                 default: 0.0
-                                unit: rad
+                                unit: deg
                                 description: Design variable bound
                             upper_bound: *angbound
                     hub_diameter:
@@ -733,18 +733,18 @@ properties:
                                                             properties:
                                                                 lower_bound:
                                                                     type: number
-                                                                    unit: rad
+                                                                    unit: deg
                                                                     description: Design variable bound
                                                                     default: 0.0
                                                                     minimum: 0.0
-                                                                    maximum: 3.141592653589793 #180 deg
+                                                                    maximum: 180.0 #180 deg
                                                                 upper_bound:
                                                                     type: number
-                                                                    unit: rad
+                                                                    unit: deg
                                                                     description: Design variable bound
-                                                                    default: 0.1
+                                                                    default: 5.0
                                                                     minimum: 0.0
-                                                                    maximum: 3.141592653589793 #180 deg
+                                                                    maximum: 180.0 #180 deg
             mooring:
                 type: object
                 description: Design variables associated with the mooring system
@@ -931,10 +931,10 @@ properties:
                             flag: *flag
                             margin:
                                 type: number
-                                default: 0.05233 # 3 deg
+                                default: 5.0 # 5 deg
                                 minimum: 0.0
-                                maximum: 0.5
-                                unit: radians
+                                maximum: 30.0
+                                unit: deg
                     chord:
                         type: object
                         description: Enforcing the maximum chord length limit at all points along blade span.
@@ -1288,8 +1288,8 @@ properties:
                                 type: number
                                 default: 1e-3
                                 minimum: 1e-5
-                                maximum: 1.0
-                                unit: radian
+                                maximum: 30.0
+                                unit: deg
                                 description: Upper limit of angular deflection
                     stator_deflection:
                         type: object
@@ -1301,7 +1301,7 @@ properties:
                     stator_angle:
                         type: object
                         default: {}
-                        description: Allowable non-torque angular deflection of the nose or bedplate, in radians, at the generator stator attachment
+                        description: Allowable non-torque angular deflection of the nose or bedplate, in degrees, at the generator stator attachment
                         properties:
                             flag: *flag
                             upper_bound: *angular_upper
@@ -1322,10 +1322,10 @@ properties:
                         properties:
                             upper_bound: &upang
                                 type: number
-                                default: 0.17453292519943295 # 10 deg
-                                minimum: 0.017453292519943295 # 1 deg
-                                maximum: 0.7853981633974483 # 45 deg
-                                unit: rad
+                                default: 10.0 
+                                minimum: 1.0 
+                                maximum: 45.0 
+                                unit: deg
                     survival_heel: *heelang
                     max_surge:
                         type: object

--- a/wisdem/inputs/modeling_schema.yaml
+++ b/wisdem/inputs/modeling_schema.yaml
@@ -73,7 +73,7 @@ properties:
                         description: Min pitch angle of the Cp-Ct-Cq-surfaces
                     max_pitch_perf_surfaces:
                         type: number
-                        default: 30.
+                        default: 40.
                         description: Max pitch angle of the Cp-Ct-Cq-surfaces
                     n_tsr_perf_surfaces:
                         type: integer


### PR DESCRIPTION
This work started to fix a missing feature where output yamls weren't updated in the start and end non dimensional arc positions of layers and webs in the composite-made beams following windIO v2.0. The PR then grew to address #709 converting some leftover fields in the analysis options yaml still defined in radians to degrees. Lastly, the max value of pitch angle for the Cp-Ct-Cq TSR tables was increased from 30deg to 40deg to avoid issues in WEIS. If tests pass, this PR is good to go