### PR TITLE
consistent ordering of D, t arrays with s-coordinate for hss

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - sortedcontainers
   - statsmodels>=0.14.5
   - pip
-  - windIO>=2.1.1
+  - windio>=2.1.1
   - wombat>=0.13.1
   - pip:
     - dearpygui

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -41,7 +41,7 @@ dependencies:
   - sphinx-copybutton
   - sphinx-jsonschema
   - sphinx_rtd_theme>=1.3
-  - windIO>=2.1.1
+  - windio>=2.1.1
   - wombat>=0.13.1
   - pip:
     - dearpygui

--- a/wisdem/drivetrainse/layout.py
+++ b/wisdem/drivetrainse/layout.py
@@ -456,7 +456,7 @@ class GearedLayout(Layout):
     Parameters
     ----------
     hss_diameter : numpy array[2], [m]
-        HSS outer diameter from hub to bearing 2
+        HSS outer diameter from gearbox to generator
     hss_wall_thickness : numpy array[2], [m]
         HSS wall thickness
     bedplate_flange_width : float, [m]
@@ -582,7 +582,7 @@ class GearedLayout(Layout):
 
         # ------- hss, lss, and bearing properties ----------------
         # Compute center of mass based on area
-        m_hss, cm_hss, I_hss, _, _ = rod_prop(s_hss, D_hss, t_hss, hss_rho)
+        m_hss, cm_hss, I_hss, _, _ = rod_prop(s_hss, np.flip(D_hss), np.flip(t_hss), hss_rho)
         if hss_mass_user > 0.0:
             m_hss = hss_mass_user
         outputs["hss_mass"] = m_hss
@@ -590,7 +590,7 @@ class GearedLayout(Layout):
         outputs["hss_I"] = I_hss
         outputs["s_hss"] = s_hss
 
-        m_lss, cm_lss, I_lss, Ds_lss, ts_lss = rod_prop(s_lss, D_lss, t_lss, lss_rho)
+        m_lss, cm_lss, I_lss, Ds_lss, ts_lss = rod_prop(s_lss, np.flip(D_lss), np.flip(t_lss), lss_rho)
         if lss_mass_user > 0.0:
             m_lss = lss_mass_user
         outputs["lss_mass"] = m_lss


### PR DESCRIPTION
## Purpose
Work in #718 was incomplete and needed a couple more edits to align D,t arrays with s-coordinate for geared layouts

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
