### PR TITLE
Twist opt

### DIFF
--- a/docs/examples/03_blade/tutorial.rst
+++ b/docs/examples/03_blade/tutorial.rst
@@ -7,6 +7,7 @@ This example walks through a blade optimization problem with increasing complexi
 
 All of the iterations use the same geometry input file, ``BAR-USC.yaml``, which describes a baseline design from the NREL-Sandia Big Adaptive Rotor (BAR) project described in this GitHub [repository](https://github.com/NREL/BAR_Designs).
 This blade uses carbon fiber-reinforced polymer in the spar cap design.  The same ``modeling_options.yaml`` file is also common to all iterations and shows that all WISDEM modules are called. The file has dozens of optional inputs hidden. The full list of inputs is available among the :ref:`modeling-options`.
+Note only one important new flag: `place_webs_caps` is activated in the modeling options for this example, which allows the optimizer to adjust the placement of the spar caps, the layers linked to those, and shear webs to be placed chordwise along the maximum thickness of the blade. This is a new feature that can be used in any optimization problem, but it is only activated in this example for demonstration purposes.
 The example file runs four cases one after the other for testing purposes. To run the cases one by one, make sure to comment out all cases at lines 15-18 except the case that should run.
 
 

--- a/examples/03_blade/modeling_options.yaml
+++ b/examples/03_blade/modeling_options.yaml
@@ -8,6 +8,7 @@ WISDEM:
         spar_cap_ps: Spar_cap_ps
         te_ss: TE_reinf_ss
         te_ps: TE_reinf_ps
+        place_webs_caps: True
     DriveSE:
         flag: True
     TowerSE:             # Options of TowerSE module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wisdem"
-version = "4.2.1"
+version = "4.2.2"
 description = "Wind-Plant Integrated System Design & Engineering Model"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/wisdem/glue_code/gc_LoadInputs.py
+++ b/wisdem/glue_code/gc_LoadInputs.py
@@ -887,6 +887,18 @@ class WindTurbineOntologyPython(object):
                                 self.wt_init["components"]["blade"]["structure"]["anchors"][j][anchor_handle]["values"] = wt_opt[
                                     "blade.structure.layer_start_nd"
                                 ][i, :].tolist()
+                                if "width" in self.wt_init["components"]["blade"]["structure"]["anchors"][j]:
+                                    self.wt_init["components"]["blade"]["structure"]["anchors"][j]["width"]["grid"] = wt_opt[
+                                        "blade.outer_shape.s"
+                                    ].tolist()
+                                    self.wt_init["components"]["blade"]["structure"]["anchors"][j]["width"]["values"] = wt_opt[
+                                        "blade.structure.layer_width_adjusted"
+                                    ][i, :].tolist()
+                                if "plane_intersection" in self.wt_init["components"]["blade"]["structure"]["anchors"][j]:
+                                    self.wt_init["components"]["blade"]["structure"]["anchors"][j]["plane_intersection"]["offset"]["grid"] = wt_opt["blade.outer_shape.s"].tolist()
+                                    self.wt_init["components"]["blade"]["structure"]["anchors"][j]["plane_intersection"]["offset"]["values"] = wt_opt[
+                                        "blade.structure.layer_offset_adjusted"
+                                    ][i, :].tolist()
                                 break
                     # Update end_nd_arc for the anchor
                     if "anchor" in self.wt_init["components"]["blade"]["structure"]["layers"][i]["end_nd_arc"]:
@@ -900,6 +912,18 @@ class WindTurbineOntologyPython(object):
                                 self.wt_init["components"]["blade"]["structure"]["anchors"][j][anchor_handle]["values"] = wt_opt[
                                     "blade.structure.layer_end_nd"
                                 ][i, :].tolist()
+                                if "width" in self.wt_init["components"]["blade"]["structure"]["anchors"][j]:
+                                    self.wt_init["components"]["blade"]["structure"]["anchors"][j]["width"]["grid"] = wt_opt[
+                                        "blade.outer_shape.s"
+                                    ].tolist()
+                                    self.wt_init["components"]["blade"]["structure"]["anchors"][j]["width"]["values"] = wt_opt[
+                                        "blade.structure.layer_width_adjusted"
+                                    ][i, :].tolist()
+                                if "plane_intersection" in self.wt_init["components"]["blade"]["structure"]["anchors"][j]:
+                                    self.wt_init["components"]["blade"]["structure"]["anchors"][j]["plane_intersection"]["offset"]["grid"] = wt_opt["blade.outer_shape.s"].tolist()
+                                    self.wt_init["components"]["blade"]["structure"]["anchors"][j]["plane_intersection"]["offset"]["values"] = wt_opt[
+                                        "blade.structure.layer_offset_adjusted"
+                                    ][i, :].tolist()
                                 break
                 for i in range(self.modeling_options["WISDEM"]["RotorSE"]["n_webs"]):
                     # Update start_nd_arc for the anchor
@@ -914,6 +938,11 @@ class WindTurbineOntologyPython(object):
                                 self.wt_init["components"]["blade"]["structure"]["anchors"][j][anchor_handle]["values"] = wt_opt[
                                     "blade.structure.web_start_nd"
                                 ][i, :].tolist()
+                                if "plane_intersection" in self.wt_init["components"]["blade"]["structure"]["anchors"][j]:
+                                    self.wt_init["components"]["blade"]["structure"]["anchors"][j]["plane_intersection"]["offset"]["grid"] = wt_opt["blade.outer_shape.s"].tolist()
+                                    self.wt_init["components"]["blade"]["structure"]["anchors"][j]["plane_intersection"]["offset"]["values"] = wt_opt[
+                                        "blade.structure.web_offset_adjusted"
+                                    ][i, :].tolist()
                                 break
                     # Update end_nd_arc for the anchor
                     if "anchor" in self.wt_init["components"]["blade"]["structure"]["webs"][i]["end_nd_arc"]:
@@ -927,6 +956,11 @@ class WindTurbineOntologyPython(object):
                                 self.wt_init["components"]["blade"]["structure"]["anchors"][j][anchor_handle]["values"] = wt_opt[
                                     "blade.structure.web_end_nd"
                                 ][i, :].tolist()
+                                if "plane_intersection" in self.wt_init["components"]["blade"]["structure"]["anchors"][j]:
+                                    self.wt_init["components"]["blade"]["structure"]["anchors"][j]["plane_intersection"]["offset"]["grid"] = wt_opt["blade.outer_shape.s"].tolist()
+                                    self.wt_init["components"]["blade"]["structure"]["anchors"][j]["plane_intersection"]["offset"]["values"] = wt_opt[
+                                        "blade.structure.web_offset_adjusted"
+                                    ][i, :].tolist()
                                 break
 
 

--- a/wisdem/glue_code/gc_PoseOptimization.py
+++ b/wisdem/glue_code/gc_PoseOptimization.py
@@ -1340,7 +1340,7 @@ class PoseOptimization(object):
                 wt_init["components"]["blade"]["outer_shape"]["twist"]["values"],
             )
             init_twist_opt = twist_interpolator(wt_opt["blade.opt_var.s_opt_twist"])
-            wt_opt["blade.opt_var.twist_opt"] = init_twist_opt
+            wt_opt["blade.opt_var.twist_opt"] = np.deg2rad(init_twist_opt)
             wt_opt["blade.opt_var.s_opt_chord"] = np.linspace(0.0, 1.0, blade_opt["aero_shape"]["chord"]["n_opt"])
             chord_interpolator = PchipInterpolator(
                 wt_init["components"]["blade"]["outer_shape"]["chord"]["grid"],

--- a/wisdem/glue_code/gc_WT_DataStruc.py
+++ b/wisdem/glue_code/gc_WT_DataStruc.py
@@ -784,7 +784,7 @@ class Blade(om.Group):
                 self.connect("opt_var.layer_%d_opt" % i, "ps.layer_%d_opt" % i)
                 self.connect("opt_var.s_opt_layer_%d" % i, "ps.s_opt_layer_%d" % i)
 
-            self.connect("outer_shape.s", "ps.s")
+            self.connect("outer_shape.s", ["structure.s", "ps.s"])
             self.connect("compute_coord_xy_dim.coord_xy_dim", "structure.coord_xy_dim")
             self.connect("structure.layer_thickness", "ps.layer_thickness_original")
 
@@ -1229,10 +1229,185 @@ class Blade_Structure(om.Group):
         ivc.add_output("sigma_max", val=0.0, units="Pa", desc="Max stress on each blade root bolt.")
 
         self.add_subsystem(
+            "place_webs_caps",
+            Place_Webs_Caps(rotorse_options=rotorse_options),
+            promotes=["*"],
+        )
+
+        self.add_subsystem(
             "compute_structure",
             Compute_Blade_Structure(rotorse_options=rotorse_options),
             promotes=["*"],
         )
+
+class Place_Webs_Caps(om.ExplicitComponent):
+    def initialize(self):
+        self.options.declare("rotorse_options")
+
+    def setup(self):
+        rotorse_options = self.options["rotorse_options"]
+        self.n_span = n_span = rotorse_options["n_span"]
+        self.n_webs = n_webs = rotorse_options["n_webs"]
+        self.n_layers = n_layers = rotorse_options["n_layers"]
+        self.n_xy = n_xy = rotorse_options["n_xy"]  # Number of coordinate points to describe the airfoil geometry
+
+        # self.add_input(
+        #     "chord", val=np.zeros(n_span), units="m", desc="1D array of the chord values defined along blade span."
+        # )
+        # self.add_input(
+        #     "section_offset_y", val=np.zeros(n_span), units="m", desc="1D array of the airfoil position relative to the reference axis, specifying the distance in meters along the chordline from the reference axis to the leading edge. 0 means that the airfoil is pinned at the leading edge, a positive offset means that the leading edge is upstream of the reference axis in local chordline coordinates, and a negative offset that the leading edge aft of the reference axis.",
+        # )
+        self.add_input(
+            "s",
+            val=np.zeros(n_span),
+            desc="1D array of the non-dimensional spanwise grid defined along blade axis (0-blade root, 1-blade tip)",
+        )
+        self.add_discrete_input(
+            "build_web",
+            val=[False] * n_webs,
+            desc="1D array of boolean values indicating whether to build a web from offset and rotation.",
+        )
+        self.add_input(
+            "web_offset",
+            val=np.zeros((n_webs, n_span)),
+            units="m",
+            desc="2D array of the dimensional offset of a web with respect to the reference axis. The first dimension represents each web, the second dimension represents each entry along blade span.",
+        )
+        self.add_discrete_input(
+            "build_layer",
+            val=np.zeros(n_layers),
+            desc="1D array of boolean values indicating how to build a layer. 0 - start and end are set constant, 1 - from offset and rotation suction side, 2 - from offset and rotation pressure side, 3 - LE and width, 4 - TE SS width, 5 - TE PS width, 6 - locked to another layer. Negative values place the layer on webs (-1 first web, -2 second web, etc.).",
+        )
+        self.add_input(
+            "layer_width",
+            val=np.zeros((n_layers, n_span)),
+            units="m",
+            desc="2D array of the width of the layers. The first dimension represents each layer, the second dimension represents span.",
+        )
+        self.add_input(
+            "coord_xy_dim",
+            val=np.zeros((n_span, n_xy, 2)),
+            units="m",
+            desc="3D array of the dimensional x and y airfoil coordinates of the airfoils interpolated along span for n_span stations. The origin is placed at the pitch axis.",
+        )
+
+        # Outputs
+        self.add_output(
+            "web_offset_adjusted",
+            val=np.zeros((n_webs, n_span)),
+            units="m",
+            desc="2D array of the dimensional offset of a web with respect to the reference axis. The first dimension represents each web, the second dimension represents each entry along blade span.",
+        )
+        self.add_output(
+            "layer_offset_adjusted",
+            val=np.zeros((n_layers, n_span)),
+            units="m",
+            desc="2D array of the dimensional offset of a layer with respect to the reference axis. The first dimension represents each layer, the second dimension represents each entry along blade span.",
+        )
+        self.add_output(
+            "layer_width_adjusted",
+            val=np.zeros((n_layers, n_span)),
+            units="m",
+            desc="2D array of the width of the layers. The first dimension represents each layer, the second dimension represents span.",
+        )
+
+    def compute(self, inputs, outputs, discrete_inputs, discrete_outputs):
+        start = 0.1
+        end = 0.9
+        id = [np.argmin(np.abs(inputs["s"] - start)), np.argmin(np.abs(inputs["s"] - end))]
+
+        x_tmax = np.zeros(2)
+
+        # get coordinates of the two profiles at 10% and 90% span and find the x location of max thickness for each of the two profiles
+        for i in range(2):
+            x = inputs["coord_xy_dim"][id[i], :, 0]
+            y = inputs["coord_xy_dim"][id[i], :, 1]
+            # find LE and chord
+            i_le = np.argmin(x)
+            x_le = x[i_le]
+            x_te = np.max(x) # robust TE x
+            chord = x_te - x_le
+            # Split profile into the two sides at LE
+            x1, y1 = x[:i_le+1], y[:i_le+1]
+            x2, y2 = x[i_le:], y[i_le:] 
+            # Make both sides increasing in x for interpolation
+            if x1[0] > x1[-1]:
+                x1, y1 = x1[::-1], y1[::-1]
+            if x2[0] > x2[-1]:
+                x2, y2 = x2[::-1], y2[::-1]
+            # Common x-range where both sides exist
+            x_min = max(x1.min(), x2.min())
+            x_max = min(x1.max(), x2.max())
+            xq = np.linspace(x_min, x_max, int(1e+3))
+
+            y1q = np.interp(xq, x1, y1)
+            y2q = np.interp(xq, x2, y2)
+
+            thickness = np.abs(y1q - y2q)
+            i_tmax = np.argmax(thickness)
+
+            # t_max = thickness[i_tmax] # max thickness [m]
+            x_tmax[i] = xq[i_tmax] # x-location [m]
+
+        # Interpolate with constant slope extrapolation outside [0.1, 0.9]
+        s_ref = inputs["s"][id]
+        slope = (x_tmax[1] - x_tmax[0]) / (s_ref[1] - s_ref[0])
+        x_tmax_interp = np.interp(inputs["s"], s_ref, x_tmax)
+        
+        # Apply constant slope extrapolation
+        mask_below = inputs["s"] < s_ref[0]
+        mask_above = inputs["s"] > s_ref[1]
+        x_tmax_interp[mask_below] = x_tmax[0] + slope * (inputs["s"][mask_below] - s_ref[0])
+        x_tmax_interp[mask_above] = x_tmax[1] + slope * (inputs["s"][mask_above] - s_ref[1])
+
+        # Start placement logic
+        webs_do_not_fit = True
+        le_coord = inputs["coord_xy_dim"][:, :, 0].min(axis=1)
+        te_coord = inputs["coord_xy_dim"][:, :, 0].max(axis=1)
+        # Compute distance between the webs
+        distance_webs = np.abs([inputs["web_offset"][1, id[0]] - inputs["web_offset"][0, id[0]], inputs["web_offset"][1, id[1]] - inputs["web_offset"][0, id[1]]])
+        while webs_do_not_fit:
+            slope = (distance_webs[1] - distance_webs[0]) / (s_ref[1] - s_ref[0])
+            distance_webs_interp = np.interp(inputs["s"], s_ref, distance_webs)
+            
+            # Apply constant slope extrapolation
+            distance_webs_interp[mask_below] = distance_webs[0] + slope * (inputs["s"][mask_below] - s_ref[0])
+            distance_webs_interp[mask_above] = distance_webs[1] + slope * (inputs["s"][mask_above] - s_ref[1])
+
+            for j in range(self.n_webs):
+                if discrete_inputs["build_web"][j]:
+                    outputs["web_offset_adjusted"][j, :] = x_tmax_interp - distance_webs_interp / 2 + j * distance_webs_interp / (self.n_webs - 1)
+
+            # Check the webs fit within the blade profile with a 5% chord margin from the leading and trailing edge. If not, reduce the distance between the webs and repeat until they fit.
+            if all(all(outputs["web_offset_adjusted"][j, :] > le_coord + 0.05*chord) for j in range(self.n_webs)) and all(all(outputs["web_offset_adjusted"][j, :] < te_coord - 0.05*chord) for j in range(self.n_webs)):
+                webs_do_not_fit = False
+            if webs_do_not_fit:
+                distance_webs *= 0.9
+            if any(distance_webs) < 0.:
+                logger.debug("The distance between the webs has been reduced to less than 0 and it still does not fit within the blade profile. Please adjust the input parameters.")
+                webs_do_not_fit = False
+        
+        outputs["layer_width_adjusted"] = inputs["layer_width"]
+        for j in range(self.n_layers):
+            if discrete_inputs["build_layer"][j] in [1, 2]: # from offset and rotation
+                outputs["layer_offset_adjusted"][j, :] = x_tmax_interp
+
+                # Check the layers fit within the blade profile with a 5% chord margin from the leading and trailing edge. If not, reduce the width to 50% of chord
+                for i in range(self.n_span):
+                    caps_fit = True
+                    k = 1
+                    chord = te_coord[i] - le_coord[i]
+                    while caps_fit:
+                        k *=0.9
+                        if outputs["layer_offset_adjusted"][j, i] - 0.5 * outputs["layer_width_adjusted"][j, i] < le_coord[i] + 0.05*chord:
+                            outputs["layer_width_adjusted"][j, i] = k*chord
+                            caps_fit = False
+                        elif outputs["layer_offset_adjusted"][j, i] + 0.5 * outputs["layer_width_adjusted"][j, i] > te_coord[i] - 0.05*chord:
+                            outputs["layer_width_adjusted"][j, i] = k*chord
+                            caps_fit = False
+                        if k < 0.1:
+                            logger.debug("The layer width of the spar caps has been reduced to less than 10pc of the chord and it still does not fit within the blade profile. Please adjust the input parameters.")
+                            break
 
 
 class Compute_Blade_Structure(om.ExplicitComponent):
@@ -1257,7 +1432,7 @@ class Compute_Blade_Structure(om.ExplicitComponent):
             desc="2D array of the non-dimensional end point defined along the outer profile of a web. The TE suction side is 0, the TE pressure side is 1. The first dimension represents each web, the second dimension represents each entry along blade span.",
         )
         self.add_input(
-            "web_offset",
+            "web_offset_adjusted",
             val=np.zeros((n_webs, n_span)),
             units="m",
             desc="2D array of the dimensional offset of a web with respect to the reference axis. The first dimension represents each web, the second dimension represents each entry along blade span.",
@@ -1284,13 +1459,13 @@ class Compute_Blade_Structure(om.ExplicitComponent):
             desc="2D array of the end_nd_arc of the layers. The first dimension represents each layer, the second dimension represents span.",
         )
         self.add_input(
-            "layer_width",
+            "layer_width_adjusted",
             val=np.zeros((n_layers, n_span)),
             units="m",
             desc="2D array of the width of the layers. The first dimension represents each layer, the second dimension represents span.",
         )
         self.add_input(
-            "layer_offset",
+            "layer_offset_adjusted",
             val=np.zeros((n_layers, n_span)),
             units="m",
             desc="2D array of the dimensional offset of a layer with respect to the reference axis. The first dimension represents each layer, the second dimension represents each entry along blade span.",
@@ -1346,7 +1521,6 @@ class Compute_Blade_Structure(om.ExplicitComponent):
         web_end_nd = np.zeros((self.n_webs, self.n_span))
         layer_start_nd = np.zeros((self.n_layers, self.n_span))
         layer_end_nd = np.zeros((self.n_layers, self.n_span))
-        import matplotlib.pyplot as plt
 
         # Compute the start and end points of the webs
         for j in range(self.n_webs):
@@ -1357,7 +1531,7 @@ class Compute_Blade_Structure(om.ExplicitComponent):
                 theta = np.deg2rad(inputs["web_rotation"][j])
                 rotation_matrix = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
                 xy_coord_rotated = xy_coord_i @ rotation_matrix.T
-                web_offset = inputs["web_offset"][j, i]
+                web_offset = inputs["web_offset_adjusted"][j, i]
                 idx_web_ss = np.argmin(abs(xy_coord_rotated[:idx_le, 0] - web_offset))
                 idx_web_ps = np.argmin(abs(xy_coord_rotated[idx_le:, 0] - web_offset)) + idx_le
                 xy_arc_i = arc_length(xy_coord_i)
@@ -1394,14 +1568,14 @@ class Compute_Blade_Structure(om.ExplicitComponent):
                     theta = np.deg2rad(inputs["layer_rotation"][j])
                     rotation_matrix = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
                     xy_coord_rotated = xy_coord_i @ rotation_matrix.T
-                    layer_offset = inputs["layer_offset"][j, i]
+                    layer_offset = inputs["layer_offset_adjusted"][j, i]
                     if discrete_inputs["build_layer"][j] == 1:  # suction side
                         idx_layer = np.argmin(abs(xy_coord_rotated[:idx_le, 0] - layer_offset))
                     else:  # pressure side
                         idx_layer = np.argmin(abs(xy_coord_rotated[idx_le:, 0] - layer_offset)) + idx_le
                     xy_arc_i = arc_length(xy_coord_i)
                     arc_L_i = xy_arc_i[-1]
-                    width_i = inputs["layer_width"][j, i]
+                    width_i = inputs["layer_width_adjusted"][j, i]
 
                     layer_start_nd[j, i] = (xy_arc_i[idx_layer] - 0.5 * width_i) / arc_L_i
                     layer_end_nd[j, i] = (xy_arc_i[idx_layer] + 0.5 * width_i) / arc_L_i
@@ -1413,7 +1587,7 @@ class Compute_Blade_Structure(om.ExplicitComponent):
                     arc_L_i = xy_arc_i[-1]
                     idx_le = np.argmin(xy_coord_i[:, 0])
                     LE_loc_i = xy_arc_i[idx_le]
-                    width_i = inputs["layer_width"][j, i]
+                    width_i = inputs["layer_width_adjusted"][j, i]
 
                     layer_start_nd[j, i] = (LE_loc_i - 0.5 * width_i) / arc_L_i
                     layer_end_nd[j, i] = (LE_loc_i + 0.5 * width_i) / arc_L_i
@@ -1423,7 +1597,7 @@ class Compute_Blade_Structure(om.ExplicitComponent):
                     xy_coord_i = inputs["coord_xy_dim"][i, :, :]
                     xy_arc_i = arc_length(xy_coord_i)
                     arc_L_i = xy_arc_i[-1]
-                    width_i = inputs["layer_width"][j, i]
+                    width_i = inputs["layer_width_adjusted"][j, i]
 
                     layer_start_nd[j, i] = 0.0
                     layer_end_nd[j, i] = width_i / arc_L_i
@@ -1433,7 +1607,7 @@ class Compute_Blade_Structure(om.ExplicitComponent):
                     xy_coord_i = inputs["coord_xy_dim"][i, :, :]
                     xy_arc_i = arc_length(xy_coord_i)
                     arc_L_i = xy_arc_i[-1]
-                    width_i = inputs["layer_width"][j, i]
+                    width_i = inputs["layer_width_adjusted"][j, i]
 
                     layer_start_nd[j, i] = 1.0 - width_i / arc_L_i
                     layer_end_nd[j, i] = 1.0

--- a/wisdem/glue_code/gc_WT_DataStruc.py
+++ b/wisdem/glue_code/gc_WT_DataStruc.py
@@ -715,6 +715,16 @@ class Blade(om.Group):
         # Import outer shape BEM
         self.add_subsystem("outer_shape", Blade_Outer_Shape(rotorse_options=rotorse_options))
 
+        # Interpolate airfoil profiles and coordinates
+        self.add_subsystem(
+            "interp_airfoils",
+            Blade_Interp_Airfoils(rotorse_options=rotorse_options),
+        )
+        # Connections from oute_shape_bem to interp_airfoils
+        self.connect("outer_shape.s", "interp_airfoils.s")
+        self.connect("outer_shape.rthick_yaml", "interp_airfoils.rthick_yaml")
+        self.connect("opt_var.af_position", "interp_airfoils.af_position")
+        
         # Parametrize blade outer shape
         self.add_subsystem(
             "pa", ParametrizeBladeAero(rotorse_options=rotorse_options, opt_options=opt_options)
@@ -727,21 +737,7 @@ class Blade(om.Group):
         self.connect("outer_shape.s", "pa.s")
         self.connect("outer_shape.chord", "pa.chord_original")
         self.connect("outer_shape.section_offset_y", "pa.section_offset_y")
-
-        # Interpolate airfoil profiles and coordinates
-        self.add_subsystem(
-            "interp_airfoils",
-            Blade_Interp_Airfoils(rotorse_options=rotorse_options),
-        )
-
-        # Connections from oute_shape_bem to interp_airfoils
-        self.connect("outer_shape.s", "interp_airfoils.s")
-        self.connect("outer_shape.rthick_yaml", "interp_airfoils.rthick_yaml")
-        self.connect("pa.chord_param", ["interp_airfoils.chord", "compute_coord_xy_dim.chord"])
-        self.connect(
-            "pa.section_offset_y_param", ["interp_airfoils.section_offset_y", "compute_coord_xy_dim.section_offset_y"]
-        )
-        self.connect("opt_var.af_position", "interp_airfoils.af_position")
+        self.connect("interp_airfoils.ac_interp", "pa.ac_interp")
 
         self.add_subsystem("high_level_blade_props", ComputeHighLevelBladeProperties(rotorse_options=rotorse_options))
         self.connect("ref_axis", "high_level_blade_props.blade_ref_axis_user")
@@ -758,7 +754,8 @@ class Blade(om.Group):
         )
         self.connect("pa.twist_param", "compute_coord_xy_dim.twist")
         self.connect("high_level_blade_props.blade_ref_axis", "compute_coord_xy_dim.ref_axis")
-
+        self.connect("pa.chord_param", "compute_coord_xy_dim.chord")
+        self.connect("pa.section_offset_y_param", "compute_coord_xy_dim.section_offset_y")
         self.connect("interp_airfoils.coord_xy_interp", "compute_coord_xy_dim.coord_xy_interp")
 
         # If the flag is true, generate the 3D x,y,z points of the outer blade shape
@@ -880,15 +877,6 @@ class Blade_Interp_Airfoils(om.ExplicitComponent):
             "s",
             val=np.zeros(n_span),
             desc="1D array of the non-dimensional spanwise grid defined along blade axis (0-blade root, 1-blade tip)",
-        )
-        self.add_input(
-            "section_offset_y",
-            val=np.zeros(n_span),
-            units="m",
-            desc="1D array of the airfoil position relative to the reference axis, specifying the distance in meters along the chordline from the reference axis to the leading edge. 0 means that the airfoil is pinned at the leading edge, a positive offset means that the leading edge is upstream of the reference axis in local chordline coordinates, and a negative offset that the leading edge aft of the reference axis..",
-        )
-        self.add_input(
-            "chord", val=np.zeros(n_span), units="m", desc="1D array of the chord values defined along blade span."
         )
 
         # Airfoil properties

--- a/wisdem/glue_code/gc_WT_DataStruc.py
+++ b/wisdem/glue_code/gc_WT_DataStruc.py
@@ -507,7 +507,7 @@ class Blade(om.Group):
         opt_var.add_output(
             "twist_opt",
             val=np.ones(opt_options["design_variables"]["blade"]["aero_shape"]["twist"]["n_opt"]),
-            units="deg",
+            units="rad",
         )
         opt_var.add_output(
             "chord_opt",

--- a/wisdem/glue_code/gc_WT_DataStruc.py
+++ b/wisdem/glue_code/gc_WT_DataStruc.py
@@ -1250,6 +1250,7 @@ class Place_Webs_Caps(om.ExplicitComponent):
         self.n_webs = n_webs = rotorse_options["n_webs"]
         self.n_layers = n_layers = rotorse_options["n_layers"]
         self.n_xy = n_xy = rotorse_options["n_xy"]  # Number of coordinate points to describe the airfoil geometry
+        self.place_webs_caps = rotorse_options["place_webs_caps"]
 
         # self.add_input(
         #     "chord", val=np.zeros(n_span), units="m", desc="1D array of the chord values defined along blade span."
@@ -1272,6 +1273,12 @@ class Place_Webs_Caps(om.ExplicitComponent):
             val=np.zeros((n_webs, n_span)),
             units="m",
             desc="2D array of the dimensional offset of a web with respect to the reference axis. The first dimension represents each web, the second dimension represents each entry along blade span.",
+        )
+        self.add_input(
+            "layer_offset",
+            val=np.zeros((n_layers, n_span)),
+            units="m",
+            desc="2D array of the dimensional offset of a layer with respect to the reference axis. The first dimension represents each layer, the second dimension represents each entry along blade span.",
         )
         self.add_discrete_input(
             "build_layer",
@@ -1312,103 +1319,107 @@ class Place_Webs_Caps(om.ExplicitComponent):
         )
 
     def compute(self, inputs, outputs, discrete_inputs, discrete_outputs):
-        start = 0.1
-        end = 0.9
-        id = [np.argmin(np.abs(inputs["s"] - start)), np.argmin(np.abs(inputs["s"] - end))]
+        if self.place_webs_caps:
+            start = 0.1
+            end = 0.9
+            id = [np.argmin(np.abs(inputs["s"] - start)), np.argmin(np.abs(inputs["s"] - end))]
 
-        x_tmax = np.zeros(2)
+            x_tmax = np.zeros(2)
 
-        # get coordinates of the two profiles at 10% and 90% span and find the x location of max thickness for each of the two profiles
-        for i in range(2):
-            x = inputs["coord_xy_dim"][id[i], :, 0]
-            y = inputs["coord_xy_dim"][id[i], :, 1]
-            # find LE and chord
-            i_le = np.argmin(x)
-            x_le = x[i_le]
-            x_te = np.max(x) # robust TE x
-            chord = x_te - x_le
-            # Split profile into the two sides at LE
-            x1, y1 = x[:i_le+1], y[:i_le+1]
-            x2, y2 = x[i_le:], y[i_le:] 
-            # Make both sides increasing in x for interpolation
-            if x1[0] > x1[-1]:
-                x1, y1 = x1[::-1], y1[::-1]
-            if x2[0] > x2[-1]:
-                x2, y2 = x2[::-1], y2[::-1]
-            # Common x-range where both sides exist
-            x_min = max(x1.min(), x2.min())
-            x_max = min(x1.max(), x2.max())
-            xq = np.linspace(x_min, x_max, int(1e+3))
+            # get coordinates of the two profiles at 10% and 90% span and find the x location of max thickness for each of the two profiles
+            for i in range(2):
+                x = inputs["coord_xy_dim"][id[i], :, 0]
+                y = inputs["coord_xy_dim"][id[i], :, 1]
+                # find LE and chord
+                i_le = np.argmin(x)
+                x_le = x[i_le]
+                x_te = np.max(x) # robust TE x
+                chord = x_te - x_le
+                # Split profile into the two sides at LE
+                x1, y1 = x[:i_le+1], y[:i_le+1]
+                x2, y2 = x[i_le:], y[i_le:] 
+                # Make both sides increasing in x for interpolation
+                if x1[0] > x1[-1]:
+                    x1, y1 = x1[::-1], y1[::-1]
+                if x2[0] > x2[-1]:
+                    x2, y2 = x2[::-1], y2[::-1]
+                # Common x-range where both sides exist
+                x_min = max(x1.min(), x2.min())
+                x_max = min(x1.max(), x2.max())
+                xq = np.linspace(x_min, x_max, int(1e+3))
 
-            y1q = np.interp(xq, x1, y1)
-            y2q = np.interp(xq, x2, y2)
+                y1q = np.interp(xq, x1, y1)
+                y2q = np.interp(xq, x2, y2)
 
-            thickness = np.abs(y1q - y2q)
-            i_tmax = np.argmax(thickness)
+                thickness = np.abs(y1q - y2q)
+                i_tmax = np.argmax(thickness)
 
-            # t_max = thickness[i_tmax] # max thickness [m]
-            x_tmax[i] = xq[i_tmax] # x-location [m]
+                # t_max = thickness[i_tmax] # max thickness [m]
+                x_tmax[i] = xq[i_tmax] # x-location [m]
 
-        # Interpolate with constant slope extrapolation outside [0.1, 0.9]
-        s_ref = inputs["s"][id]
-        slope = (x_tmax[1] - x_tmax[0]) / (s_ref[1] - s_ref[0])
-        x_tmax_interp = np.interp(inputs["s"], s_ref, x_tmax)
-        
-        # Apply constant slope extrapolation
-        mask_below = inputs["s"] < s_ref[0]
-        mask_above = inputs["s"] > s_ref[1]
-        x_tmax_interp[mask_below] = x_tmax[0] + slope * (inputs["s"][mask_below] - s_ref[0])
-        x_tmax_interp[mask_above] = x_tmax[1] + slope * (inputs["s"][mask_above] - s_ref[1])
-
-        # Start placement logic
-        webs_do_not_fit = True
-        le_coord = inputs["coord_xy_dim"][:, :, 0].min(axis=1)
-        te_coord = inputs["coord_xy_dim"][:, :, 0].max(axis=1)
-        # Compute distance between the webs
-        distance_webs = np.abs([inputs["web_offset"][1, id[0]] - inputs["web_offset"][0, id[0]], inputs["web_offset"][1, id[1]] - inputs["web_offset"][0, id[1]]])
-        while webs_do_not_fit:
-            slope = (distance_webs[1] - distance_webs[0]) / (s_ref[1] - s_ref[0])
-            distance_webs_interp = np.interp(inputs["s"], s_ref, distance_webs)
+            # Interpolate with constant slope extrapolation outside [0.1, 0.9]
+            s_ref = inputs["s"][id]
+            slope = (x_tmax[1] - x_tmax[0]) / (s_ref[1] - s_ref[0])
+            x_tmax_interp = np.interp(inputs["s"], s_ref, x_tmax)
             
             # Apply constant slope extrapolation
-            distance_webs_interp[mask_below] = distance_webs[0] + slope * (inputs["s"][mask_below] - s_ref[0])
-            distance_webs_interp[mask_above] = distance_webs[1] + slope * (inputs["s"][mask_above] - s_ref[1])
+            mask_below = inputs["s"] < s_ref[0]
+            mask_above = inputs["s"] > s_ref[1]
+            x_tmax_interp[mask_below] = x_tmax[0] + slope * (inputs["s"][mask_below] - s_ref[0])
+            x_tmax_interp[mask_above] = x_tmax[1] + slope * (inputs["s"][mask_above] - s_ref[1])
 
-            for j in range(self.n_webs):
-                if discrete_inputs["build_web"][j]:
-                    outputs["web_offset_adjusted"][j, :] = x_tmax_interp - distance_webs_interp / 2 + j * distance_webs_interp / (self.n_webs - 1)
+            # Start placement logic
+            webs_do_not_fit = True
+            le_coord = inputs["coord_xy_dim"][:, :, 0].min(axis=1)
+            te_coord = inputs["coord_xy_dim"][:, :, 0].max(axis=1)
+            # Compute distance between the webs
+            distance_webs = np.abs([inputs["web_offset"][1, id[0]] - inputs["web_offset"][0, id[0]], inputs["web_offset"][1, id[1]] - inputs["web_offset"][0, id[1]]])
+            while webs_do_not_fit:
+                slope = (distance_webs[1] - distance_webs[0]) / (s_ref[1] - s_ref[0])
+                distance_webs_interp = np.interp(inputs["s"], s_ref, distance_webs)
+                
+                # Apply constant slope extrapolation
+                distance_webs_interp[mask_below] = distance_webs[0] + slope * (inputs["s"][mask_below] - s_ref[0])
+                distance_webs_interp[mask_above] = distance_webs[1] + slope * (inputs["s"][mask_above] - s_ref[1])
 
-            # Check the webs fit within the blade profile with a 5% chord margin from the leading and trailing edge. If not, reduce the distance between the webs and repeat until they fit.
-            if all(all(outputs["web_offset_adjusted"][j, :] > le_coord + 0.05*chord) for j in range(self.n_webs)) and all(all(outputs["web_offset_adjusted"][j, :] < te_coord - 0.05*chord) for j in range(self.n_webs)):
-                webs_do_not_fit = False
-            if webs_do_not_fit:
-                distance_webs *= 0.9
-            if any(distance_webs) < 0.:
-                logger.debug("The distance between the webs has been reduced to less than 0 and it still does not fit within the blade profile. Please adjust the input parameters.")
-                webs_do_not_fit = False
-        
-        outputs["layer_width_adjusted"] = inputs["layer_width"]
-        for j in range(self.n_layers):
-            if discrete_inputs["build_layer"][j] in [1, 2]: # from offset and rotation
-                outputs["layer_offset_adjusted"][j, :] = x_tmax_interp
+                for j in range(self.n_webs):
+                    if discrete_inputs["build_web"][j]:
+                        outputs["web_offset_adjusted"][j, :] = x_tmax_interp - distance_webs_interp / 2 + j * distance_webs_interp / (self.n_webs - 1)
 
-                # Check the layers fit within the blade profile with a 5% chord margin from the leading and trailing edge. If not, reduce the width to 50% of chord
-                for i in range(self.n_span):
-                    caps_fit = True
-                    k = 1
-                    chord = te_coord[i] - le_coord[i]
-                    while caps_fit:
-                        k *=0.9
-                        if outputs["layer_offset_adjusted"][j, i] - 0.5 * outputs["layer_width_adjusted"][j, i] < le_coord[i] + 0.05*chord:
-                            outputs["layer_width_adjusted"][j, i] = k*chord
-                            caps_fit = False
-                        elif outputs["layer_offset_adjusted"][j, i] + 0.5 * outputs["layer_width_adjusted"][j, i] > te_coord[i] - 0.05*chord:
-                            outputs["layer_width_adjusted"][j, i] = k*chord
-                            caps_fit = False
-                        if k < 0.1:
-                            logger.debug("The layer width of the spar caps has been reduced to less than 10pc of the chord and it still does not fit within the blade profile. Please adjust the input parameters.")
-                            break
+                # Check the webs fit within the blade profile with a 5% chord margin from the leading and trailing edge. If not, reduce the distance between the webs and repeat until they fit.
+                if all(all(outputs["web_offset_adjusted"][j, :] > le_coord + 0.05*chord) for j in range(self.n_webs)) and all(all(outputs["web_offset_adjusted"][j, :] < te_coord - 0.05*chord) for j in range(self.n_webs)):
+                    webs_do_not_fit = False
+                if webs_do_not_fit:
+                    distance_webs *= 0.9
+                if any(distance_webs) < 0.:
+                    logger.debug("The distance between the webs has been reduced to less than 0 and it still does not fit within the blade profile. Please adjust the input parameters.")
+                    webs_do_not_fit = False
+            
+            outputs["layer_width_adjusted"] = inputs["layer_width"]
+            for j in range(self.n_layers):
+                if discrete_inputs["build_layer"][j] in [1, 2]: # from offset and rotation
+                    outputs["layer_offset_adjusted"][j, :] = x_tmax_interp
 
+                    # Check the layers fit within the blade profile with a 5% chord margin from the leading and trailing edge. If not, reduce the width to 50% of chord
+                    for i in range(self.n_span):
+                        caps_fit = True
+                        k = 1
+                        chord = te_coord[i] - le_coord[i]
+                        while caps_fit:
+                            k *=0.9
+                            if outputs["layer_offset_adjusted"][j, i] - 0.5 * outputs["layer_width_adjusted"][j, i] < le_coord[i] + 0.05*chord:
+                                outputs["layer_width_adjusted"][j, i] = k*chord
+                                caps_fit = False
+                            elif outputs["layer_offset_adjusted"][j, i] + 0.5 * outputs["layer_width_adjusted"][j, i] > te_coord[i] - 0.05*chord:
+                                outputs["layer_width_adjusted"][j, i] = k*chord
+                                caps_fit = False
+                            if k < 0.1:
+                                logger.debug("The layer width of the spar caps has been reduced to less than 10pc of the chord and it still does not fit within the blade profile. Please adjust the input parameters.")
+                                break
+        else:
+            outputs["web_offset_adjusted"] = inputs["web_offset"]
+            outputs["layer_offset_adjusted"] = inputs["layer_offset"]
+            outputs["layer_width_adjusted"] = inputs["layer_width"]
 
 class Compute_Blade_Structure(om.ExplicitComponent):
     def initialize(self):

--- a/wisdem/inputs/modeling_schema.yaml
+++ b/wisdem/inputs/modeling_schema.yaml
@@ -161,6 +161,10 @@ properties:
                         type: boolean
                         default: True
                         description: Flag switching on and off the 3d DU-Selig airfoil correction implemented in Polar.py
+                    place_webs_caps:
+                        type: boolean
+                        default: False
+                        description: Whether or not to optimize the placement of the webs and caps in the blade for along maximum chordwise thickness.
             DriveSE:
                 type: object
                 default: {}

--- a/wisdem/rotorse/parametrize_rotor.py
+++ b/wisdem/rotorse/parametrize_rotor.py
@@ -65,6 +65,11 @@ class ParametrizeBladeAero(om.ExplicitComponent):
             units="m",
             desc="1D array of the airfoil position relative to the reference axis, specifying the distance in meters along the chordline from the reference axis to the leading edge. The distribution is the original from the yaml.",
         )
+        self.add_input(
+            "ac_interp",
+            val=np.zeros(n_span),
+            desc="1D array of the aerodynamic center of the blade defined along span.",
+        )
         # Outputs
         self.add_output(
             "twist_param",
@@ -123,7 +128,8 @@ class ParametrizeBladeAero(om.ExplicitComponent):
         outputs["slope_twist_constr"] = slope_twist_constr
         # Update section_offset_y
         outputs["section_offset_y_param"] = inputs["section_offset_y"] * outputs["chord_param"] / inputs["chord_original"]
-        
+        # Alternative approach following the aerodynamic center, which probably needs some smoothing first though
+        # outputs["section_offset_y_param"] = inputs["ac_interp"] * outputs["chord_param"]
 
 
 class ParametrizeBladeStruct(om.ExplicitComponent):

--- a/wisdem/test/test_rotorse/test_blade_cost.py
+++ b/wisdem/test/test_rotorse/test_blade_cost.py
@@ -137,6 +137,7 @@ class TestBC(unittest.TestCase):
         wt_initial = WindTurbineOntologyPython(fname_wt_input, fname_modeling_options, fname_opt_options)
         wt_init, modeling_options, opt_options = wt_initial.get_input_data()
         modeling_options["WISDEM"]["RotorSE"]["flag"] = False
+        modeling_options["WISDEM"]["RotorSE"]["place_webs_caps"] = False
         modeling_options["WISDEM"]["DriveSE"]["flag"] = False
         modeling_options["WISDEM"]["TowerSE"]["flag"] = False
         modeling_options["flags"]["blade"] = True


### PR DESCRIPTION
A bit embarrassing, but the bug raised in #709 was still present. This PR finally fixes it. This PR does two more things:
- It adds the option to optimize the chord wise placement of spar caps and shear webs to make sure they are aligned with the maximum airfoil thickness
- It updates the chord wise offsets and widths of the blade structural anchors in the output yaml, respecting the convention of windIO v2.1

Once tests pass, we should merge and tag a minor release