### PR TITLE
more official support of windiov2.1 with backwards compatibility on gearbox user overrides

### DIFF
--- a/wisdem/glue_code/gc_WT_InitModel.py
+++ b/wisdem/glue_code/gc_WT_InitModel.py
@@ -798,11 +798,25 @@ def assign_drivetrain_values(wt_opt, modeling_options, drivetrain, yaw, flags, u
             wt_opt["drivetrain.bedplate_web_thickness"] = drivetrain["bedplate"]["web_thickness"]
             wt_opt["drivetrain.gear_configuration"] = drivetrain["gearbox"]["gear_configuration"].lower()
             wt_opt["drivetrain.planet_numbers"] = drivetrain["gearbox"]["planet_numbers"]
-            if "mass_user" in drivetrain["gearbox"]:
+            if "mass" in drivetrain["gearbox"]:
+                wt_opt["drivetrain.gearbox_mass_user"] = drivetrain["gearbox"]["mass"]
+            elif "mass_user" in drivetrain["gearbox"]:
                 wt_opt["drivetrain.gearbox_mass_user"] = drivetrain["gearbox"]["mass_user"]
-            if "gearbox_radius_user" in drivetrain["gearbox"]:
+            elif "gearbox_mass_user" in drivetrain:
+                wt_opt["drivetrain.gearbox_mass_user"] = drivetrain["gearbox_mass_user"]
+                
+            if "radius" in drivetrain["gearbox"]:
+                wt_opt["drivetrain.gearbox_radius_user"] = drivetrain["gearbox"]["radius"]
+            elif "radius_user" in drivetrain["gearbox"]:
+                wt_opt["drivetrain.gearbox_radius_user"] = drivetrain["gearbox"]["radius_user"]
+            elif "gearbox_radius_user" in drivetrain:
                 wt_opt["drivetrain.gearbox_radius_user"] = drivetrain["gearbox_radius_user"]
-            if "gearbox_length_user" in drivetrain["gearbox"]:
+                
+            if "length" in drivetrain["gearbox"]:
+                wt_opt["drivetrain.gearbox_length_user"] = drivetrain["gearbox"]["length"]
+            if "length_user" in drivetrain["gearbox"]:
+                wt_opt["drivetrain.gearbox_length_user"] = drivetrain["gearbox"]["length_user"]
+            if "gearbox_length_user" in drivetrain:
                 wt_opt["drivetrain.gearbox_length_user"] = drivetrain["gearbox_length_user"]
 
     if user_elastic:


### PR DESCRIPTION
Per latest [comment](https://github.com/NLRWindSystems/WISDEM/issues/593#issuecomment-4719834359) in #593 

## Purpose
Align user inputs with WindIO v2.1 syntax

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
