### PR TITLE
Continue to support weis, wisdem after Numpy 2.5 changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wisdem"
-version = "4.2.4"
+version = "4.2.5"
 description = "Wind-Plant Integrated System Design & Engineering Model"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/wisdem/ccblade/ccblade.py
+++ b/wisdem/ccblade/ccblade.py
@@ -175,11 +175,11 @@ class CCAirfoil(object):
         also uses a small amount of smoothing to help remove spurious multiple solutions.
         """
 
-        cl = self.cl_spline.ev(alpha, Re)
-        cd = self.cd_spline.ev(alpha, Re)
+        cl = self.cl_spline.ev(alpha, Re)[0]
+        cd = self.cd_spline.ev(alpha, Re)[0]
 
         if self.use_cm and return_cm:
-            cm = self.cm_spline.ev(alpha, Re)
+            cm = self.cm_spline.ev(alpha, Re)[0]
             return cl, cd, cm
         else:
             return cl, cd
@@ -974,7 +974,6 @@ class CCBlade(object):
                 args = (self.r[i], self.chord[i], self.theta[i], self.af[i], Vx[i], Vy[i])
 
             # derivatives of residual
-
             (
                 a[i],
                 ap[i],

--- a/wisdem/glue_code/gc_WT_InitModel.py
+++ b/wisdem/glue_code/gc_WT_InitModel.py
@@ -748,16 +748,27 @@ def assign_drivetrain_values(wt_opt, modeling_options, drivetrain, yaw, flags, u
         wt_opt["drivetrain.bedplate_material"] = drivetrain["bedplate"]["material"]
         if "mass_user" in drivetrain["bedplate"]:
             wt_opt["drivetrain.bedplate_mass_user"] = drivetrain["bedplate"]["mass_user"]
-        if "brake_mass_user" in drivetrain["other_components"]:
+            
+        if "brake_mass" in drivetrain["other_components"]:
+            wt_opt["drivetrain.brake_mass_user"] = drivetrain["other_components"]["brake_mass"]
+        elif "brake_mass_user" in drivetrain["other_components"]:
             wt_opt["drivetrain.brake_mass_user"] = drivetrain["other_components"]["brake_mass_user"]
+            
         if "mb1_mass_user" in drivetrain["other_components"]:
             wt_opt["drivetrain.mb1_mass_user"] = drivetrain["other_components"]["mb1_mass_user"]
         if "mb2_mass_user" in drivetrain["other_components"]:
             wt_opt["drivetrain.mb2_mass_user"] = drivetrain["other_components"]["mb2_mass_user"]
-        if "converter_mass_user" in drivetrain["other_components"]:
+            
+        if "converter_mass" in drivetrain["other_components"]:
+            wt_opt["drivetrain.converter_mass_user"] = drivetrain["other_components"]["converter_mass"]
+        elif "converter_mass_user" in drivetrain["other_components"]:
             wt_opt["drivetrain.converter_mass_user"] = drivetrain["other_components"]["converter_mass_user"]
-        if "transformer_mass_user" in drivetrain["other_components"]:
+            
+        if "transformer_mass" in drivetrain["other_components"]:
+            wt_opt["drivetrain.transformer_mass_user"] = drivetrain["other_components"]["transformer_mass"]
+        elif "transformer_mass_user" in drivetrain["other_components"]:
             wt_opt["drivetrain.transformer_mass_user"] = drivetrain["other_components"]["transformer_mass_user"]
+            
         if "platform_mass_user" in drivetrain["other_components"]:
             wt_opt["drivetrain.platform_mass_user"] = drivetrain["other_components"]["platform_mass_user"]
         if "cover_mass_user" in drivetrain["other_components"]:

--- a/wisdem/rotorse/rotor_elasticity.py
+++ b/wisdem/rotorse/rotor_elasticity.py
@@ -1459,7 +1459,10 @@ class KI_to_Elastic(ExplicitComponent):
             # find the inertia twist
             I3 = np.array([[I_cg[n+3, m+3] for m in range(3)] for n in range(3)]) 
             (w3, v3) = np.linalg.eig(I3)
-
+            if np.iscomplexobj(w3[0]):
+                w3 = np.real(w3)
+                v3 = np.real(v3)
+                
             # This angle solve is likely working only within in [-pi/2, pi/2]
             if np.abs(v3[0,0]) < np.abs(v3[0,1]):
                 angle = np.arccos(v3[0,0])

--- a/wisdem/test/test_pyframe3dd/test_beam_theory.py
+++ b/wisdem/test/test_pyframe3dd/test_beam_theory.py
@@ -60,9 +60,9 @@ class FrameTestEXA(unittest.TestCase):
 
         # dynamics
         nM = 15  # number of desired dynamic modes of vibration
-        Mmethod = 2  # 1: subspace Jacobi     2: Stodola
+        Mmethod = 1  # 1: subspace Jacobi     2: Stodola (causes some segfaults on CI runners?)
         lump = 0  # 0: consistent mass ... 1: lumped mass matrix
-        tol = 1e-9  # mode shape tolerance
+        tol = 1e-7  # mode shape tolerance
         shift = 0.0  # shift value ... for unrestrained structures
         frame.enableDynamics(nM, Mmethod, lump, tol, shift)
 
@@ -89,7 +89,7 @@ class FrameTestEXA(unittest.TestCase):
         self.assertAlmostEqual(modal.freq[5], anal[2], -1)
 
         #### Free-free
-        shift = 10  # shift value ... for unrestrained structures
+        shift = 1e4  # shift value ... for unrestrained structures
         frame0 = Frame(nodes, reactions0, elements, options)
         frame0.enableDynamics(nM, Mmethod, lump, tol, shift)
         frame0.addLoadCase(load)

--- a/wisdem/test/test_pyframe3dd/test_beam_theory.py
+++ b/wisdem/test/test_pyframe3dd/test_beam_theory.py
@@ -60,10 +60,10 @@ class FrameTestEXA(unittest.TestCase):
 
         # dynamics
         nM = 15  # number of desired dynamic modes of vibration
-        Mmethod = 1  # 1: subspace Jacobi     2: Stodola
+        Mmethod = 2  # 1: subspace Jacobi     2: Stodola
         lump = 0  # 0: consistent mass ... 1: lumped mass matrix
         tol = 1e-9  # mode shape tolerance
-        shift = -1e3  # shift value ... for unrestrained structures
+        shift = 0.0  # shift value ... for unrestrained structures
         frame.enableDynamics(nM, Mmethod, lump, tol, shift)
 
         # load cases 1
@@ -89,6 +89,7 @@ class FrameTestEXA(unittest.TestCase):
         self.assertAlmostEqual(modal.freq[5], anal[2], -1)
 
         #### Free-free
+        shift = 10  # shift value ... for unrestrained structures
         frame0 = Frame(nodes, reactions0, elements, options)
         frame0.enableDynamics(nM, Mmethod, lump, tol, shift)
         frame0.addLoadCase(load)

--- a/wisdem/test/test_towerse/test_tower.py
+++ b/wisdem/test/test_towerse/test_tower.py
@@ -485,13 +485,14 @@ class TestTowerSE(unittest.TestCase):
                 [0.1778494, 0.1404714, 0.0988901, 0.0900522, 0.0322198, 0.0101666],
             ],
         )
-        npt.assert_allclose(
-            prob["tower.turbine_F"].T,
-            [
-                [ 1.28474420e+06, -2.32830644e-10, -3.76200526e+06],
-                [ 9.30198601e+05, -4.07453626e-10, -4.39569594e+06],
-            ], 1e-6
-        )
+        x = prob["tower.turbine_F"].T
+        x[np.abs(x)<1e-8] = 0.0
+        npt.assert_allclose(x,
+                            [
+                                [ 1.28474420e+06, 0.0, -3.76200526e+06],
+                                [ 9.30198601e+05, 0.0, -4.39569594e+06],
+                            ], 1e-6
+                            )
         npt.assert_almost_equal(
             prob["tower.turbine_M"].T,
             [
@@ -539,12 +540,13 @@ class TestTowerSE(unittest.TestCase):
                 [0.0518572, 0.0513707, 0.0486856, 0.066858 , 0.064029 , 0.061868 ],
             ],
         )
-        npt.assert_allclose(
-            prob["tower.turbine_F"].T,
-            [
-                [ 1.28474420e+06, -2.32830644e-10, -3.76200526e+06],
-                [ 9.30198601e+05, -4.07453626e-10, -4.39569594e+06],
-            ], 1e-6
+        x = prob["tower.turbine_F"].T
+        x[np.abs(x)<1e-8] = 0.0
+        npt.assert_allclose(x,
+                            [
+                                [ 1.28474420e+06, 0.0, -3.76200526e+06],
+                                [ 9.30198601e+05, 0.0, -4.39569594e+06],
+                            ], 1e-6
         )
         npt.assert_almost_equal(
             prob["tower.turbine_M"].T,

--- a/wisdem/towerse/tower.py
+++ b/wisdem/towerse/tower.py
@@ -366,7 +366,8 @@ class TowerFrame(om.ExplicitComponent):
         mID = np.arange(n, dtype=np.int_)+1 # 1-based indexing for frame3dd
         m_add = total_lumped_mass
         cg_add = np.zeros([3, n])
-        cg_add[:,n-1] = inputs["rna_cg"]/total_lumped_mass[-1]
+        if total_lumped_mass[-1] > 0:
+            cg_add[:,n-1] = inputs["rna_cg"]/total_lumped_mass[-1]
         I_add = np.zeros([6,n])
         I_add[:,n-1] = inputs["rna_I"]
         add_gravity = False


### PR DESCRIPTION
## Purpose
Numpy 2.5 has some different output standards on some functions and is finicky about inputs to others.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
- x ] I have run existing tests which pass locally with my changes
- [x] I have added new tests or examples that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
