### PR TITLE
Fix depreciation of set_design_var

### DIFF
--- a/wisdem/optimization_drivers/nsga2_driver.py
+++ b/wisdem/optimization_drivers/nsga2_driver.py
@@ -439,7 +439,7 @@ class NSGA2Driver(Driver):
         desvar_new = design_vars_fronts[0][median_idx, :]
         for name in desvars:
             i, j = self._desvar_idx[name]
-            self.set_design_var(name, desvar_new[i:j])
+            self._set_design_var(name, desvar_new[i:j])
         with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
             self._run_solve_nonlinear()
             rec.abs = 0.0
@@ -471,7 +471,7 @@ class NSGA2Driver(Driver):
         out_of_bounds = False
         for name in self._designvars:
             i, j = self._desvar_idx[name]
-            self.set_design_var(name, x[i:j])
+            self._set_design_var(name, x[i:j])
 
             # Check that design variables are within bounds
             if (


### PR DESCRIPTION
## Purpose

Fix OpenMDAO 3.45.0 compatibility: replace deprecated `set_design_var` with `_set_design_var` in NSGA2Driver. 

The public `set_design_var` method was deprecated in OpenMDAO 3.40.0 and set to expire in version 3.45.0 (which is now in use). OpenMDAO's guidance directs driver subclasses to use the private `_set_design_var` instead, which is the sanctioned internal API for optimizers setting design variables in driver-scaled space.

This broke:
- The `iea22_raft_opt_driver.py` example in WEIS (see [WEIS CI job](https://github.com/NLRWindSystems/WEIS/actions/runs/29784966944/job/88494392908))
- 4 of 6 tests in `test_nsga2_driver.py`

All built-in OpenMDAO drivers (pyoptsparse, pymoo, scipy, modopt) already use `_set_design_vars` / `_set_design_var` internally, so this aligns NSGA2Driver with the framework's current pattern.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Testing

All 6 tests in `test_nsga2_driver.py` now pass.

## Checklist
<!-- _Put an `x` in the boxes that apply._ -->

- [x ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
