### PR TITLE
resolve OpenMDAO deprecating self.set_design_var in Drivers for self._set_design_var

### DIFF
--- a/wisdem/optimization_drivers/nsga2_driver.py
+++ b/wisdem/optimization_drivers/nsga2_driver.py
@@ -439,7 +439,7 @@ class NSGA2Driver(Driver):
         desvar_new = design_vars_fronts[0][median_idx, :]
         for name in desvars:
             i, j = self._desvar_idx[name]
-            self.set_design_var(name, desvar_new[i:j])
+            self._set_design_var(name, desvar_new[i:j])
         with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
             self._run_solve_nonlinear()
             rec.abs = 0.0
@@ -471,7 +471,7 @@ class NSGA2Driver(Driver):
         out_of_bounds = False
         for name in self._designvars:
             i, j = self._desvar_idx[name]
-            self.set_design_var(name, x[i:j])
+            self._set_design_var(name, x[i:j])
 
             # Check that design variables are within bounds
             if (


### PR DESCRIPTION
…_set_design_var

<!-- Delete the text explanations below these headers and replace them with information about your PR.
Please first consult the [developer guide](https://weis.readthedocs.io/en/latest/how_to_contribute_code.html) to make sure your PR follows all code, testing, and documentation conventions. -->

## Purpose
<!-- Explain the goal of this pull request. If it addresses an existing issue be sure to link to it. Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal. If it accomplishes multiple goals, it may be best to create separate PR's for each. -->

Resolve OpenMDAO deprecating self.set_design_var in Drivers for self._set_design_var. This change makes WISDEM compatible with OpenMDAO 3.45. This fix is needed for tests to pass for H2Integrate, so getting these into the release version very soon would be helpful.

## Type of change
<!-- What types of change is it?
_Select the appropriate type(s) that describe this PR_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
Run tests, specifically `wisdem/test/test_optimization_drivers/test_nsga2_driver.py`

## Checklist
<!-- _Put an `x` in the boxes that apply._ -->

- [x] I have run existing tests which pass locally with my changes
- [-] I have added new tests or examples that prove my fix is effective or that my feature works
- [-] I have added necessary documentation
